### PR TITLE
Push buttons with interrupts

### DIFF
--- a/K197Display.ino
+++ b/K197Display.ino
@@ -150,7 +150,6 @@ void handleSerial() { // Here we want to use Serial, rather than DebugOut
     printHelp();
     return;
   }
-
   if (strcasecmp_P(buf, PSTR("wdt")) == 0) {
     Serial.println(F("Testing watchdog reset"));
     Serial.flush();
@@ -220,8 +219,8 @@ void myButtonCallback(K197UIeventsource eventSource, K197UIeventType eventType) 
 
   // Handle the special case of REL and DB pressed simultaneously (enter cal mode)
   if ( (eventSource==K197key_REL || eventSource==K197key_DB) && pushbuttons.isSimultaneousPress(K197key_REL, K197key_DB)) {
-      uiman.showFullScreen();
-      uiman.updateDisplay();
+      //uiman.showFullScreen();
+      //uiman.updateDisplay();
       if (eventType==UIeventPress) {
           pinConfigure(MB_REL, PIN_DIR_OUTPUT | PIN_OUT_HIGH);
           pinConfigure(MB_DB, PIN_DIR_OUTPUT | PIN_OUT_HIGH);

--- a/K197Display.ino
+++ b/K197Display.ino
@@ -197,10 +197,10 @@ void handleSerial() { // Here we want to use Serial, rather than DebugOut
 k197ButtonCluster pushbuttons; ///< this object is used to interact with the
                                ///< push-button cluster
 
-#define K197_MB_CLICK_TIME                                                     \
+#define K197_MB_CLICK_TIME_us                                                     \
   750 ///< how much a click should last when sent to the K197 (us)
-#define K197_MB_CLICK_TIME2                                                     \
-  350 ///< how much we should wait after a click is sent to the K197 (us)
+#define K197_MB_CLICK_TIME2_ms                                                     \
+  300 ///< how much we should wait after a click is sent to the K197 (ms)
 
 /*!
       @brief Callback for push button events
@@ -214,19 +214,19 @@ k197ButtonCluster pushbuttons; ///< this object is used to interact with the
 void myButtonCallback(K197UIeventsource eventSource, K197UIeventType eventType) {
   dxUtil.checkFreeStack();
   if (uiman.handleUIEvent(eventSource, eventType)) { // UI related event, no need to do more
-    DebugOut.print(F("PIN=")); DebugOut.print((uint8_t) eventSource);
-    DebugOut.print(F(" "));
-    k197ButtonCluster::DebugOut_printEventName(eventType);
-    DebugOut.println(F("Btn handled by UI"));
+    //DebugOut.print(F("PIN=")); DebugOut.print((uint8_t) eventSource);
+    //DebugOut.print(F(" "));
+    //k197ButtonCluster::DebugOut_printEventName(eventType);
+    //DebugOut.println(F("Btn handled by UI"));
     return;
   }
   if (uiman.isSplitScreen()) return; // Nothing to do in split screen mode
   
-  DebugOut.print(F("Btn "));
+  //DebugOut.print(F("Btn "));
   if(pushbuttons.isTransparentMode()) return; // No need to do anything here
   switch (eventSource) {
   case K197key_STO:
-    DebugOut.print(F("STO"));
+    //DebugOut.print(F("STO"));
     if (eventType == UIeventPress) {
       pinConfigure(MB_STO, PIN_DIR_OUTPUT | PIN_OUT_HIGH);
     } else if (eventType == UIeventRelease) {
@@ -243,13 +243,13 @@ void myButtonCallback(K197UIeventsource eventSource, K197UIeventType eventType) 
     break;
   case K197key_REL:
     // We cannot use UIeventPress for REL because we need to discriminate a long press from a (short) click
-    DebugOut.print(F("REL"));
+    //DebugOut.print(F("REL"));
     if (eventType == UIeventClick) {
-      DebugOut.print('.');
+      //DebugOut.print('.');
       pinConfigure(MB_REL, PIN_DIR_OUTPUT | PIN_OUT_HIGH);
-      delayMicroseconds(K197_MB_CLICK_TIME);
+      delayMicroseconds(K197_MB_CLICK_TIME_us);
       pinConfigure(MB_REL, PIN_DIR_INPUT | PIN_OUT_LOW);
-      delayMicroseconds(K197_MB_CLICK_TIME2);
+      delay(K197_MB_CLICK_TIME2_ms);
     }
     break;
   case K197key_DB:
@@ -261,9 +261,9 @@ void myButtonCallback(K197UIeventsource eventSource, K197UIeventType eventType) 
     }
     break;
   }
-  DebugOut.print(F(" "));
-  k197ButtonCluster::DebugOut_printEventName(eventType);
-  DebugOut.println();
+  //DebugOut.print(F(" "));
+  //k197ButtonCluster::DebugOut_printEventName(eventType);
+  //DebugOut.println();
 
 }
 

--- a/K197Display.ino
+++ b/K197Display.ino
@@ -51,8 +51,6 @@ recurring issues
 #include "UImanager.h"
 
 #include "K197PushButtons.h"
-k197ButtonCluster pushbuttons; ///< this object is used to interact with the
-                               ///< push-button cluster
 #include "debugUtil.h"
 #include "dxUtil.h"
 

--- a/K197Display.ino
+++ b/K197Display.ino
@@ -28,10 +28,6 @@ if the relevant flag is set)
 is the expected one, and print the information to DebugOut
   - Finally, check for pushbutton events (this will trigger the callback)
 
-    At startup button presses from the UI push buttons are mirrored towards the
-motherboard (transparent mode). At the end of the arduino setup() transparent
-mode is turned off, so that we can assign new functions to the buttons
-
     Note: the way we detect SPI client related problems in loop is not
 fool-proof, but statistically we should print out something if there are
 recurring issues
@@ -223,7 +219,6 @@ void myButtonCallback(K197UIeventsource eventSource, K197UIeventType eventType) 
   if (uiman.isSplitScreen()) return; // Nothing to do in split screen mode
   
   //DebugOut.print(F("Btn "));
-  if(pushbuttons.isTransparentMode()) return; // No need to do anything here
   switch (eventSource) {
   case K197key_STO:
     //DebugOut.print(F("STO"));
@@ -313,7 +308,6 @@ void setup() {
     DebugOut.println(F("BT is off"));
   }
 
-  pushbuttons.setTransparentMode(false);
   delay(100);
 
   dxUtil.checkFreeStack();

--- a/K197Display.ino
+++ b/K197Display.ino
@@ -11,22 +11,24 @@
   This file is part of the Arduino K197Display sketch, please see
   https://github.com/alx2009/K197Display for more information
 
-  This is the main file for the sketch. In addition to setup() and loop(), the
-following functions are implemented in this file:
+  This is the main file for the sketch. The following functions are implemented
+in this file:
      - Management of the serial user interface
      - Callback for push button events (some handled directly, some passed to
 UImanager)
-     - Setup invokes the setup methods of all key objects such as K197dev, uiman
-and pushbuttons
+     - Arduino setup: invokes the setup methods of all key objects such as
+K197dev, uiman and pushbuttons
+     - Arduino main loop function, loop()
 
-  All the magic happens in the main loop. For each loop iteration:
+  All the magic happens in the main loop function. For each loop() iteration:
   - handle commands from Serial if any has been received
   - check if 197dev has got new data (this should happen 3 times a second)
   - if new data available ask uiman to update the display (and print to Serial
 if the relevant flag is set)
   - check if K197dev detected SPI collisions and if the number of data received
 is the expected one, and print the information to DebugOut
-  - Finally, check for pushbutton events (this will trigger the callback)
+  - Finally, check for pushbutton events (if there are events, the callback is
+called)
 
     Note: the way we detect SPI client related problems in loop is not
 fool-proof, but statistically we should print out something if there are
@@ -36,11 +38,13 @@ recurring issues
 /**************************************************************************/
 // TODO wish list:
 //  Move statistics options to own submenu
-//  consider moving to interrupts for button events (as of now it is possible to miss very quick button clicks)
+//  Hold
 //  Autohold
-//  Save/retrieve setting to EEPROM
+//  Save/retrieve settings to EEPROM
+//  Move seg2char to flash
 //  Graph mode
-// Bug: Enable scrolling menu backward even if the item is not selectable
+//  Optimize interrupts
+// Bug2fix: Enable scrolling menu backward even if the item is not selectable
 
 #include "K197device.h"
 
@@ -49,20 +53,13 @@ recurring issues
 #include "K197PushButtons.h"
 k197ButtonCluster pushbuttons; ///< this object is used to interact with the
                                ///< push-button cluster
-
-#define K197_MB_CLICK_TIME_us                                                     \
-  750 ///< how much a click should last when sent to the K197 (us)
-#define K197_MB_CLICK_TIME2_ms                                                     \
-  300 ///< how much we should wait after a click is sent to the K197 (ms)
-
 #include "debugUtil.h"
 #include "dxUtil.h"
 
 #include "BTmanager.h"
 
 #include "pinout.h"
-const char CH_SPACE =
-    ' '; ///< using a constant (defined in pinout.h) saves some RAM
+const char CH_SPACE = ' '; ///< using a global constant saves some RAM
 
 #ifndef DB_28_PINS
 #error AVR32DB28 or AVR64DB28 or AVR128DB28 microcontroller required, using dxCore
@@ -70,13 +67,16 @@ const char CH_SPACE =
 
 bool msg_printout = false; ///< if true prints raw messages to DebugOut
 
+////////////////////////////////////////////////////////////////////////////////////
+// Management of the serial user interface
+////////////////////////////////////////////////////////////////////////////////////
 /*!
       @brief print the prompt to Serial
 */
 void printPrompt() { // Here we want to use Serial, rather than DebugOut
-  dxUtil.reportStack();
   Serial.println();
-  Serial.print(F("> "));
+  dxUtil.reportStack();
+  Serial.println(F("> "));
 }
 
 /*!
@@ -189,13 +189,17 @@ void handleSerial() { // Here we want to use Serial, rather than DebugOut
   } else if ((strcasecmp_P(buf, PSTR("log")) == 0)) {
     cmdLog();
   } else if ((strcasecmp_P(buf, PSTR("contrast")) == 0)) {
-    cmdContrast();   
+    cmdContrast();
   } else if ((strcasecmp_P(buf, PSTR(" ")) == 0)) {
     // do nothing;
   } else {
     printError(buf);
   }
 }
+
+////////////////////////////////////////////////////////////////////////////////////
+// Callback for push button events
+////////////////////////////////////////////////////////////////////////////////////
 
 /*!
       @brief Callback for push button events
@@ -206,34 +210,39 @@ void handleSerial() { // Here we want to use Serial, rather than DebugOut
       @param eventType one of the eventXXX constants define in class
    k197ButtonCluster
 */
-void myButtonCallback(K197UIeventsource eventSource, K197UIeventType eventType) {
+void myButtonCallback(K197UIeventsource eventSource,
+                      K197UIeventType eventType) {
   dxUtil.checkFreeStack();
-  if (uiman.handleUIEvent(eventSource, eventType)) { // UI related event, no need to do more
-    //DebugOut.print(F("PIN=")); DebugOut.print((uint8_t) eventSource);
-    //DebugOut.print(F(" "));
-    //k197ButtonCluster::DebugOut_printEventName(eventType);
-    //DebugOut.println(F("Btn handled by UI"));
+  if (uiman.handleUIEvent(eventSource,
+                          eventType)) { // UI related event, no need to do more
+    // DebugOut.print(F("PIN=")); DebugOut.print((uint8_t) eventSource);
+    // DebugOut.print(F(" "));
+    // k197ButtonCluster::DebugOut_printEventName(eventType);
+    // DebugOut.println(F("Btn handled by UI"));
     return;
   }
-  if (k197dev.isNotCal() && uiman.isSplitScreen()) return; // Nothing to do in split screen mode
+  if (k197dev.isNotCal() && uiman.isSplitScreen())
+    return; // Nothing to do in split screen mode
 
-  // Handle the special case of REL and DB pressed simultaneously (enter cal mode)
-  if ( (eventSource==K197key_REL || eventSource==K197key_DB) && pushbuttons.isSimultaneousPress(K197key_REL, K197key_DB)) {
-      //DebugOut.print(F("REL+DB"));
-      if (eventType==UIeventPress) {
-          pinConfigure(MB_REL, PIN_DIR_OUTPUT | PIN_OUT_HIGH);
-          pinConfigure(MB_DB, PIN_DIR_OUTPUT | PIN_OUT_HIGH);
-      } else if (eventType==UIeventRelease) {
-          pinConfigure(MB_REL, PIN_DIR_INPUT | PIN_OUT_LOW);
-          pinConfigure(MB_DB, PIN_DIR_INPUT | PIN_OUT_LOW);
-      }
-      return;
+  // Handle the special case of REL and DB pressed simultaneously (enter cal
+  // mode)
+  if ((eventSource == K197key_REL || eventSource == K197key_DB) &&
+      pushbuttons.isSimultaneousPress(K197key_REL, K197key_DB)) {
+    // DebugOut.print(F("REL+DB"));
+    if (eventType == UIeventPress) {
+      pinConfigure(MB_REL, PIN_DIR_OUTPUT | PIN_OUT_HIGH);
+      pinConfigure(MB_DB, PIN_DIR_OUTPUT | PIN_OUT_HIGH);
+    } else if (eventType == UIeventRelease) {
+      pinConfigure(MB_REL, PIN_DIR_INPUT | PIN_OUT_LOW);
+      pinConfigure(MB_DB, PIN_DIR_INPUT | PIN_OUT_LOW);
+    }
+    return;
   }
-  
-  //DebugOut.print(F("Btn "));
+
+  // DebugOut.print(F("Btn "));
   switch (eventSource) {
   case K197key_STO:
-    //DebugOut.print(F("STO"));
+    // DebugOut.print(F("STO"));
     if (eventType == UIeventPress) {
       pinConfigure(MB_STO, PIN_DIR_OUTPUT | PIN_OUT_HIGH);
     } else if (eventType == UIeventRelease) {
@@ -249,15 +258,10 @@ void myButtonCallback(K197UIeventsource eventSource, K197UIeventType eventType) 
     }
     break;
   case K197key_REL:
-    // We cannot use UIeventPress for REL because we need to discriminate a long press from a (short) click
-    //DebugOut.print(F("REL"));
+    // We cannot use UIeventPress for REL because we need to discriminate a long
+    // press from a (short) click
+    // DebugOut.print(F("REL"));
     if (k197dev.isNotCal() && eventType == UIeventClick) {
-      /*
-      pinConfigure(MB_REL, PIN_DIR_OUTPUT | PIN_OUT_HIGH);
-      delayMicroseconds(K197_MB_CLICK_TIME_us);
-      pinConfigure(MB_REL, PIN_DIR_INPUT | PIN_OUT_LOW);
-      delay(K197_MB_CLICK_TIME2_ms);
-      */
       pushbuttons.clickREL();
     }
     if (k197dev.isCal() && (eventType == UIeventPress)) {
@@ -275,13 +279,14 @@ void myButtonCallback(K197UIeventsource eventSource, K197UIeventType eventType) 
     }
     break;
   }
-  //DebugOut.print(F(" "));
-  //k197ButtonCluster::DebugOut_printEventName(eventType);
-  //DebugOut.println();
+  // DebugOut.print(F(" "));
+  // k197ButtonCluster::DebugOut_printEventName(eventType);
+  // DebugOut.println();
 }
 
-//static uint8_t tot=0;
-//static uint8_t pulse=0;
+////////////////////////////////////////////////////////////////////////////////////
+// Arduino setup() & loop()
+////////////////////////////////////////////////////////////////////////////////////
 
 /*!
       @brief Arduino setup function
@@ -296,12 +301,12 @@ void setup() {
   PORTF.PORTCTRL = PORT_SRL_bm;
   pushbuttons.setup();
   pushbuttons.setCallback(myButtonCallback);
-  
+
   // Handle REL and DB if they were already pushed at startup
   if (pushbuttons.isPressed(K197key_DB))
-        pinConfigure(MB_DB, PIN_DIR_OUTPUT | PIN_OUT_HIGH);
+    pinConfigure(MB_DB, PIN_DIR_OUTPUT | PIN_OUT_HIGH);
   if (pushbuttons.isPressed(K197key_REL))
-        pinConfigure(MB_REL, PIN_DIR_OUTPUT | PIN_OUT_HIGH);
+    pinConfigure(MB_REL, PIN_DIR_OUTPUT | PIN_OUT_HIGH);
 
   DebugOut.begin();
 
@@ -350,7 +355,7 @@ byte DMMReading[PACKET]; ///< buffer used to store the raw data received from
                          ///< the voltmeter main board
 
 bool collisionStatus =
-    false; ///< keep track if a collision was detcted by the SPI peripheral
+    false; ///< keep track if a collision was detected by the SPI peripheral
 
 /*!
       @brief Arduino loop function

--- a/K197Display.ino
+++ b/K197Display.ino
@@ -214,19 +214,19 @@ k197ButtonCluster pushbuttons; ///< this object is used to interact with the
 void myButtonCallback(K197UIeventsource eventSource, K197UIeventType eventType) {
   dxUtil.checkFreeStack();
   if (uiman.handleUIEvent(eventSource, eventType)) { // UI related event, no need to do more
-    // DebugOut.print(F(", PIN=")); DebugOut.print((uint8_t) eventSource);
-    // DebugOut.print(F(" "));
-    // k197ButtonCluster::DebugOut_printEventName(eventType);
-    // DebugOut.println(F("Btn handled by UI"));
+    DebugOut.print(F("PIN=")); DebugOut.print((uint8_t) eventSource);
+    DebugOut.print(F(" "));
+    k197ButtonCluster::DebugOut_printEventName(eventType);
+    DebugOut.println(F("Btn handled by UI"));
     return;
   }
   if (uiman.isSplitScreen()) return; // Nothing to do in split screen mode
   
-  // DebugOut.print(F("Btn "));
+  DebugOut.print(F("Btn "));
   if(pushbuttons.isTransparentMode()) return; // No need to do anything here
   switch (eventSource) {
   case K197key_STO:
-    // DebugOut.print(F("STO"));
+    DebugOut.print(F("STO"));
     if (eventType == UIeventPress) {
       pinConfigure(MB_STO, PIN_DIR_OUTPUT | PIN_OUT_HIGH);
     } else if (eventType == UIeventRelease) {
@@ -243,9 +243,9 @@ void myButtonCallback(K197UIeventsource eventSource, K197UIeventType eventType) 
     break;
   case K197key_REL:
     // We cannot use UIeventPress for REL because we need to discriminate a long press from a (short) click
-    // DebugOut.print(F("REL"));
+    DebugOut.print(F("REL"));
     if (eventType == UIeventClick) {
-      //DebugOut.print('.');
+      DebugOut.print('.');
       pinConfigure(MB_REL, PIN_DIR_OUTPUT | PIN_OUT_HIGH);
       delayMicroseconds(K197_MB_CLICK_TIME);
       pinConfigure(MB_REL, PIN_DIR_INPUT | PIN_OUT_LOW);
@@ -261,10 +261,9 @@ void myButtonCallback(K197UIeventsource eventSource, K197UIeventType eventType) 
     }
     break;
   }
-  // DebugOut.print(F(", PIN=")); DebugOut.print(buttonPinIn);
-  // DebugOut.print(F(" "));
-  // k197ButtonCluster::DebugOut_printEventName(eventType);
-  // DebugOut.println();
+  DebugOut.print(F(" "));
+  k197ButtonCluster::DebugOut_printEventName(eventType);
+  DebugOut.println();
 
 }
 

--- a/K197Display.ino
+++ b/K197Display.ino
@@ -275,6 +275,13 @@ void setup() {
   PORTF.PORTCTRL = PORT_SRL_bm;
   pushbuttons.setup();
   pushbuttons.setCallback(myButtonCallback);
+  
+  // Handle REL and DB if they were already pushed at startup
+  if (pushbuttons.isPressed(K197key_DB))
+        pinConfigure(MB_DB, PIN_DIR_OUTPUT | PIN_OUT_HIGH);
+  if (pushbuttons.isPressed(K197key_REL))
+        pinConfigure(MB_REL, PIN_DIR_OUTPUT | PIN_OUT_HIGH);
+
   DebugOut.begin();
 
   dxUtil.begin();

--- a/K197Display.ino
+++ b/K197Display.ino
@@ -279,10 +279,7 @@ void setup() {
   PORTD.PORTCTRL = PORT_SRL_bm;
   PORTF.PORTCTRL = PORT_SRL_bm;
   pushbuttons.setup();
-  pushbuttons.setCallback(K197key_STO, myButtonCallback);
-  pushbuttons.setCallback(K197key_RCL, myButtonCallback);
-  pushbuttons.setCallback(K197key_REL, myButtonCallback);
-  pushbuttons.setCallback(K197key_DB, myButtonCallback);
+  pushbuttons.setCallback(myButtonCallback);
   DebugOut.begin();
 
   dxUtil.begin();
@@ -374,5 +371,5 @@ void loop() {
       DebugOut.println(F("cleared"));
     }
   }
-  pushbuttons.check();
+  pushbuttons.checkNew();
 }

--- a/K197PushButtons.cpp
+++ b/K197PushButtons.cpp
@@ -98,6 +98,26 @@ inline void invoke_callback(int i, K197UIeventType eventType) {
 }
 
 /*!
+    @brief  check if a given pushbutton is pressed
+
+    @details This function checks the button status updated to the last event processed by check()
+    It does NOT reflect the current HW status. This is useful for example in the event call back
+    in order to check if two buttons have been pressed simultaneously. It will behave correctly even if there is a delay
+    in the processing of the event, and the button was already released.
+
+    @param eventSource the event source corresponding to the push button
+    @return bool true if the button was pressed at the time the last event was generated
+*/
+bool isPressed(K197UIeventsource eventSource) {
+    for (unsigned int i=0; i<(sizeof(buttonState)/sizeof(buttonState[0])); i++) {
+        if (buttonPinIn[i] == (uint8_t) eventSource) {
+            return buttonState[i] == BUTTON_PRESSED_STATE ? true : false;   
+        }
+    }
+    return false;
+}
+
+/*!
     @brief  print event name to DebugOut
 
     Printing the event name can be useful during troubleshooting
@@ -365,7 +385,7 @@ void k197ButtonCluster::checkNew(uint8_t i, uint8_t btnow, unsigned long now) {
         buttonState[i] = btnow;
         // The following actions are taken at Button release
         if (btnow == BUTTON_IDLE_STATE) { // button was just released
-          invoke_callback(i, UIeventRelease);
+            invoke_callback(i, UIeventRelease);
             if ((now - startPressed[i]) > longPressTime) {
                 invoke_callback(i, UIeventLongClick);
             } else if (startPressed[i] - lastReleased[i] < doubleClicktime) {

--- a/K197PushButtons.cpp
+++ b/K197PushButtons.cpp
@@ -108,7 +108,7 @@ inline void invoke_callback(int i, K197UIeventType eventType) {
     @param eventSource the event source corresponding to the push button
     @return bool true if the button was pressed at the time the last event was generated
 */
-bool isPressed(K197UIeventsource eventSource) {
+bool k197ButtonCluster::isPressed(K197UIeventsource eventSource) {
     for (unsigned int i=0; i<(sizeof(buttonState)/sizeof(buttonState[0])); i++) {
         if (buttonPinIn[i] == (uint8_t) eventSource) {
             return buttonState[i] == BUTTON_PRESSED_STATE ? true : false;   

--- a/K197PushButtons.cpp
+++ b/K197PushButtons.cpp
@@ -20,21 +20,24 @@
 #include "K197PushButtons.h"
 #include <Arduino.h>
 #include <Event.h>
-#define CCL_CLKSEL_gm 1
+#define CCL_CLKSEL_gm                                                          \
+  1 ///< This need to be defined to support all AVRxxDB features
 #include <Logic.h>
 
 #include "debugUtil.h"
 
 #include "pinout.h"
 
+k197ButtonCluster::buttonCallBack callBack =
+    NULL; ///< Stores the call back for each button
+
 // In the following we instantiate a bunch of arrays to keep track of the status
-// of each push button. Essentially we need timers to keep track of various time
+// of the push buttons. Essentially we need timers to keep track of various time
 // intervals (debouncing, pressed, released, log press, etc.)
 // All timers are in us (microseconds)
 
 uint8_t buttonPinIn[] = {UI_STO, UI_RCL, UI_REL,
                          UI_DB}; ///< index to pin mapping for UI push buttons
-k197ButtonCluster::buttonCallBack callBack = NULL; ///< Stores the call back for each button
 uint8_t buttonState[] = {
     BUTTON_IDLE_STATE, BUTTON_IDLE_STATE, BUTTON_IDLE_STATE,
     BUTTON_IDLE_STATE}; ///< the current reading from the button pin
@@ -44,40 +47,16 @@ unsigned long lastHold[] = {0UL, 0UL, 0UL,
                             0UL}; ///< micros() when last hold event generated
 unsigned long lastReleased[] = {0UL, 0UL, 0UL,
                                 0UL}; ///< micros() when last released
-
-/*!
-    @brief  setup the push button cluster. Must be called first, before any
-   other member function Note that for simplicity the pins used are hardwired in
-   setup()
-*/
-void k197ButtonCluster::setup() {
-  pinConfigure(UI_STO, (PIN_DIR_INPUT | PIN_PULLUP_ON | PIN_INVERT_OFF |
-                        PIN_INLVL_SCHMITT | PIN_ISC_ENABLE));
-  pinConfigure(UI_RCL, (PIN_DIR_INPUT | PIN_PULLUP_ON | PIN_INVERT_OFF |
-                        PIN_INLVL_SCHMITT | PIN_ISC_ENABLE));
-  pinConfigure(UI_REL, (PIN_DIR_INPUT | PIN_PULLUP_ON | PIN_INVERT_OFF |
-                        PIN_INLVL_SCHMITT | PIN_ISC_ENABLE));
-  pinConfigure(UI_DB, (PIN_DIR_INPUT | PIN_PULLUP_ON | PIN_INVERT_OFF |
-                       PIN_INLVL_SCHMITT | PIN_ISC_ENABLE));
-
-  attachTimerInterrupts();
-  setupClicktimer();
-}
-
 /*!
     @brief  set a call back for a push button in the cluster
 
-    Set pinCallBack to NULL to remove call back
+    Set clusterCallBack to NULL to remove call back
 
-    @param pin the pin identifying the button
-    @param pinCallBack the function (of type k197ButtonCluster:buttonCallBack)
-   that will be called to handle button events
-    @return true if pin corresponds to one of the buttons in the cluster,
-   idnicating that the callback has been set or removed succesfully. False
-   otherwise.
+    @param clusterCallBack the function (of type
+   k197ButtonCluster:buttonCallBack) that will be called to handle button events
 */
-void k197ButtonCluster::setCallback(buttonCallBack pinCallBack) {
-    callBack = pinCallBack;
+void k197ButtonCluster::setCallback(buttonCallBack clusterCallBack) {
+  callBack = clusterCallBack;
 }
 
 /*!
@@ -88,30 +67,34 @@ void k197ButtonCluster::setCallback(buttonCallBack pinCallBack) {
     @param i the array index assigned to the push button
     @param eventType the button event passed to the call back
 */
-inline void invoke_callback(int i, K197UIeventType eventType) {
+static inline void invoke_callback(int i, K197UIeventType eventType) {
   if (callBack != NULL) {
-    callBack( (K197UIeventsource) buttonPinIn[i], eventType);
+    callBack((K197UIeventsource)buttonPinIn[i], eventType);
   }
 }
 
 /*!
     @brief  check if a given pushbutton is pressed
 
-    @details This function checks the button status updated to the last event processed by check()
-    It does NOT reflect the current HW status. This is useful for example in the event call back
-    in order to check if two buttons have been pressed simultaneously. It will behave correctly even if there is a delay
-    in the processing of the event, and the button was already released.
+    @details This function checks the button status updated to the last event
+   processed by check() It does NOT reflect the current HW status. This is
+   useful for example inside the event call back in order to check if two
+   buttons have been pressed simultaneously. It will behave correctly even if
+   there is a delay in the processing of the event, and the button was already
+   released.
 
     @param eventSource the event source corresponding to the push button
-    @return bool true if the button was pressed at the time the last event was generated
+    @return bool true if the button was pressed at the time the last event was
+   generated
 */
 bool k197ButtonCluster::isPressed(K197UIeventsource eventSource) {
-    for (unsigned int i=0; i<(sizeof(buttonState)/sizeof(buttonState[0])); i++) {
-        if (buttonPinIn[i] == (uint8_t) eventSource) {
-            return buttonState[i] == BUTTON_PRESSED_STATE ? true : false;   
-        }
+  for (unsigned int i = 0; i < (sizeof(buttonState) / sizeof(buttonState[0]));
+       i++) {
+    if (buttonPinIn[i] == (uint8_t)eventSource) {
+      return buttonState[i] == BUTTON_PRESSED_STATE ? true : false;
     }
-    return false;
+  }
+  return false;
 }
 
 /*!
@@ -152,159 +135,331 @@ void k197ButtonCluster::DebugOut_printEventName(K197UIeventType event) {
 }
 
 /////////////////////////////////////////////////////////////////////////
-// Handling of button events. This is done in two stages:
-// The first stage is HW based, using the event system and the 4 CCL (one for each button). 
-// Button status changes (after CCL filter for debouncing) generate CCL interrupt. The handler queues the button state in fifo queue
-// The events are then extracted from the fifo and processed outside the interrupt handler by checkNew(). This member function must be called periodically from the main Arduino Loop. Change() will:
-// compared to the previous release, this implementation will never lose clicks (with reasonably sized fifo). 
-// At the same time most of the processing is done outside the interrupt handler which is kept reasonably small. This is needed 
-// to avoid holding with other interruts too much [currently we miss one measurement when buttons are pressed very quickly. 
-// This should be solved when dxCore start supporting more efficient interrupt handlers for the Logic library]
-// Despite the need for a fifo queue, the new implementation uses less RAM due to HW debouncing and other optimizations
+// Handling and processing of button events. This is done in two stages:
+// The first stage is HW based, using the event system and the 4 CCL (one for
+// each button). Button status changes (after CCL filter for debouncing)
+// generate CCL interrupts. The handler queues the button state in a fifo queue.
+// The events are then extracted from the fifo and processed outside the
+// interrupt handler by checkNew(). This member function must be called
+// periodically from the main Arduino Loop. Compared to the previous release,
+// this implementation will never lose clicks (with reasonably sized fifo). At
+// the same time most of the processing is done outside the interrupt handler
+// which is kept reasonably small. This is needed to avoid holding other
+// interruts [currently we still miss one measurement when buttons are
+// pressed very quickly. This should be solved when dxCore start supporting more
+// efficient interrupt handlers for the Logic library]
+// Despite the need for a fifo queue, the new implementation uses less RAM due
+// to HW debouncing and other optimizations
 /////////////////////////////////////////////////////////////////////////
 
-#define NO_DATA 0xff
-volatile static byte fifo[] {0xff,0xff,0xff,0xff, 0xff,0xff,0xff,0xff};
-#define NUM_FIFO_RECORDS ( sizeof(fifo) / sizeof(fifo[0]) )
+#define fifo_NO_DATA                                                           \
+  0xff ///< value returned when the fifo is empty (see fifo_pull())
+volatile static byte fifo_records[]{
+    0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff}; ///< array implementing the FIFO queue, see fifo_pull()
+#define fifo_MAX_RECORDS                                                       \
+  (sizeof(fifo_records) /                                                      \
+   sizeof(fifo_records[0])) ///< max number of records in the FIFO queue, see
+                            ///< fifo_pull()
 
-volatile static int8_t front=0;
+volatile static int8_t fifo_front =
+    0; // index to the front of the queue, see fifo_pull()
 // We use rear in the interrupt handler, hence the use of GPIO3
-// Initialized inside k197ButtonCluster::attachTimerInterrupts()
-#define rear GPIOR3 
+// Initialized inside k197ButtonCluster::setup()
+#define fifo_rear GPIOR3 ///< index to the rear of the queue, see fifo_pull()
 
-static inline int getSize() {
-   int size=0;
-   for (unsigned int i=0; i<NUM_FIFO_RECORDS; i++) {
-       if (fifo[i]!=NO_DATA) size++;
-   }
-   return size;
+/*!
+    @brief  get the number of records actually stored in the FIFO queue (see
+   also fifo_pull())
+    @details this function is thread safe, but the result may not be consistent
+   with previous/following calls (see fifo_pull())
+    @return the number of records currently in the FIFO queue
+*/
+static inline int fifo_getSize() {
+  int size = 0;
+  for (unsigned int i = 0; i < fifo_MAX_RECORDS; i++) {
+    if (fifo_records[i] != fifo_NO_DATA)
+      size++;
+  }
+  return size;
 }
 
-static inline bool isEmpty() {
-  return fifo[front] == NO_DATA; // self-explaining :-)
+/*!
+    @brief  check if the FIFO is empty
+    @details this function is thread safe, but the result may not be consistent
+   with previous/following calls (see fifo_pull())
+    @return true if the FIFO queue is empty
+*/
+static inline bool fifo_isEmpty() {
+  return fifo_records[fifo_front] == fifo_NO_DATA; // self-explaining :-)
 }
 
-static inline bool isFull() {
-    // If we do not have free space than the queue must be full
-    return fifo[(rear + 1) % NUM_FIFO_RECORDS] != NO_DATA; 
+/*!
+    @brief  check if the FIFO is full
+    @details this function is thread safe, but the result may not be consistent
+   with previous/following calls (see fifo_pull())
+    @return true if the FIFO queue is empty
+*/
+static inline bool fifo_isFull() {
+  // If we do not have free space than the queue must be full
+  return fifo_records[(fifo_rear + 1) % fifo_MAX_RECORDS] != fifo_NO_DATA;
 }
 
-// Utility function to push an item at the rear of the fifo
-// No check of FIFO size because a) it should not happen: no user can be that fast b) we are going to lose clicks anyway c) the user or the WDT will recover (depending on the cause) 
-// TODO: add a way to detect and recover in pull()
-static inline void push(byte b) { 
-    rear = (rear+1) % NUM_FIFO_RECORDS;
-    fifo[rear] = b;
+/*!
+    @brief push a record at the rear of the FIFO queue (see also fifo_pull())
+    @details This function is optimized for use in an interrupt handler.
+    To minimize the time spent in the interrupt handler, it does not check if
+   the FIFO is full. For this application this is acceptable because:
+    - a) button events are removed quickly enough that the queue should never
+   get full. If it does, it is a sign of a malfunction which is causing the main
+   loop to hung.
+    - b) even if we checked, we would lose some events. This implementation will
+   lose the older events.
+    - c) if the hanging persists, eventually the watchdog timeout will recover
+   the situation Note that this function is not thread safe with respect to
+   other push()= instances. It is thread safe with regard to pull(), as long as
+   the FIFO is not full. If the FIFO is full, there is a race condition with
+   fifo_pull(), wich could result in the last record pushed being lost. However,
+   if this is acceptable no long term corruption to the queue should result from
+   this.
+    @param b the record that should be pushed at the rear of the FIFO queue
+*/
+static inline void fifo_push(byte b) {
+  fifo_rear = (fifo_rear + 1) % fifo_MAX_RECORDS;
+  fifo_records[fifo_rear] = b;
 }
 
-// Utility function to pull the item at the front of the fifo
-static inline byte pull() {
-  if (isEmpty()) return NO_DATA;
-  byte x = fifo[front];
-  fifo[front] = NO_DATA; // Now this slot is empty...
-  front = (front + 1) % NUM_FIFO_RECORDS;
-  return x;  
+/*!
+    @brief pull a record at the rear of the FIFO queue
+    @details The fifo_xxx series of variables and functions implement a FIFO
+queue which is used to pass "raw" button presses and release from the interrupt
+handler to the main application thread. The particular implementation has been
+chosen so that push and pull() can run concurrently as long as the FIFO never
+gets full. The size of the FIFO has been dimensioned to ensure this is true with
+normal use of the application (see comments inside the fifo_pull() function)
+
+    File static scope is used rather than a class as this seem to generate the
+smallest and fastest interrupt handler.
+
+    A small handler and the concurrency means that we can minimize the latency
+to serve the other interrupts, in particular the SPI handler which need to be
+served quickly to avoid losing data from the K197.
+
+Note that this function is not thread safe with respect to other push()=
+instances. It is thread safe with regard to pull(), as long as the FIFO is not
+full. If the FIFO is full, there is a race condition with fifo_pull(), wich
+could result in the last record pushed being lost. However, if this is
+acceptable no long term corruption to the queue should result from this.
+    @return the record just pulled from the front of the queue (or fifo_NO_DATA
+if the queue is empty).
+*/
+static inline byte fifo_pull() {
+  if (fifo_isEmpty())
+    return fifo_NO_DATA;
+  byte x = fifo_records[fifo_front];
+  fifo_records[fifo_front] =
+      fifo_NO_DATA; // here we risk a race condition with push(), but only if
+                    // the FIFO is full
+  fifo_front = (fifo_front + 1) % fifo_MAX_RECORDS;
+  return x;
 }
 
-// Interrupt handler for the CCL vector. Whatever the CCL causing the event, we push a copy of the pushbutton pins to the fifo queue 
-// This should work in dxCore 1.5.0 when it is released...
-//ISR(CCL_CCL_vect) {
+// Interrupt handler for the CCL vector. Whatever the CCL causing the event, we
+// push a copy of the pushbutton pins to the fifo queue This should work in
+// dxCore 1.5.0 when it is released...
+// ISR(CCL_CCL_vect) {
 
-//Normal function, required with current release of dxCore
+/*!
+    @brief  Interrupt handler, called for CCL events
+    @details Each one of the 4 CCL handles a button (see also
+   k197ButtonCluster::setup()). The CCL CHANGE interrupt is used to detect a
+   change of button state after the CCL filter (for HW debouncing).
+
+    The handler simply push the logic level of the relevant pins to the rear of
+   the fifo queue (see fifo_push().
+
+    Since we use the Logic library that comes with dxCore, we have to use
+   Logic::attachInterrupt. It is not very efficient, and it is expected that a
+   future release of dxCore would support defining the handler as
+   ISR(CCL_CCL_vect). In the current form the overhead due to the handling in
+   dxCore + saving all registered before the function call means that from time
+   to time pushing a button cause an overrun on the SPI bus. Note that the
+   current implementation relies on STO being on the same I/O port as RCL, and
+   REL with DB. A future HW revision will move all 4 buttons to the same I/O
+   port, potentially optimizing the interrupt handler further.
+*/
 void CCL_interrupt_handler() {
-  //CCL.INTFLAGS =  CCL.INTFLAGS; // We prefer to enter the interrupts twice rather than missing an event
-  push( (UI_STO_VPORT.IN & (UI_STO_bm | UI_RCL_bm)) | (UI_REL_VPORT.IN & (UI_REL_bm | UI_DB_bm)) ); 
+  // CCL.INTFLAGS =  CCL.INTFLAGS; // We prefer to enter the interrupts twice
+  // rather than missing an event
+  fifo_push((UI_STO_VPORT.IN & (UI_STO_bm | UI_RCL_bm)) |
+            (UI_REL_VPORT.IN & (UI_REL_bm | UI_DB_bm)));
 }
 
-inline uint8_t getButtonState(byte b) {
+/*!
+    @brief utility function, maps from I/O pin level to the correct status of
+   the button
+    @details the current implemntation assumes 0 means pressed and !=0 means not
+   pressed
+    @return BUTTON_PRESSED_STATE or BUTTON_IDLE_STATE
+*/
+static inline uint8_t getButtonState(byte b) {
   return b == 0 ? BUTTON_PRESSED_STATE : BUTTON_IDLE_STATE;
 }
 
-void initButton(uint8_t i, uint8_t btnow, unsigned long now) {
-    buttonState[i] = btnow;
-    startPressed[i] = now;
-    lastHold[i] = now;
-    lastReleased[i] = now;
+/*!
+    @brief utility function, initialize one push button
+    @param i index of the button
+    @param btnow current state of the button (BUTTON_PRESSED_STATE or
+   BUTTON_IDLE_STATE)
+    @param now current value of micros()
+*/
+static void initButton(uint8_t i, uint8_t btnow, unsigned long now) {
+  buttonState[i] = btnow;
+  startPressed[i] = now;
+  lastHold[i] = now;
+  lastReleased[i] = now;
 }
 
-void k197ButtonCluster::attachTimerInterrupts() {
-  rear=(uint8_t) -1; //Initialize register
-  
-  // Route pins for pushbuttons to Logic block 0 & 1
+/*!
+    @brief  setup the push button cluster.
+
+    @details Must be called first, before any other member function.
+
+    Pushbutton are handled in two stages. The first stage consists of the event
+   system and the four CCLs.
+
+    The CCL are used for HW debouncing each button. One CCL for each button. The
+   CCL is set to filter any change that doesn't last for at least 4 clock
+   cycles. With the CCL clock source set to the 1024Hz clock, the debouncing
+   period is about 4 ms. This works well with the buttons used, at least when
+   they are new. Should there be a need to increase the debounce period, a timer
+   should be connected to input 2 of each CCL via the event system.
+
+    afdter the filter, the CCL CHANGE interrupt is used to detect a change of
+   button state after the CCL filter (for HW debouncing). The handler simply
+   push the logic level of the relevant pins to the rear of the fifo queue (see
+   fifo_push()).
+
+    The second stage pays off when the checkNew() method is called. This method
+   will retrieve the pin status from the fifo queue (fifo_pull()), to generate
+   the various button events at the right timing.
+
+    Timing of the events is done in checkNew() rather than in the interrupt
+   handler. This keeps the interrupt handler short but it means that the timing
+   of the log press, hold and double click events may vary a bit from time to
+   time. For this application this is fully acceptable.
+
+    The relative sequence of events is always maintained, and no button click
+   should be missed.
+*/
+void k197ButtonCluster::setup() {
+  pinConfigure(UI_STO, (PIN_DIR_INPUT | PIN_PULLUP_ON | PIN_INVERT_OFF |
+                        PIN_INLVL_SCHMITT | PIN_ISC_ENABLE));
+  pinConfigure(UI_RCL, (PIN_DIR_INPUT | PIN_PULLUP_ON | PIN_INVERT_OFF |
+                        PIN_INLVL_SCHMITT | PIN_ISC_ENABLE));
+  pinConfigure(UI_REL, (PIN_DIR_INPUT | PIN_PULLUP_ON | PIN_INVERT_OFF |
+                        PIN_INLVL_SCHMITT | PIN_ISC_ENABLE));
+  pinConfigure(UI_DB, (PIN_DIR_INPUT | PIN_PULLUP_ON | PIN_INVERT_OFF |
+                       PIN_INLVL_SCHMITT | PIN_ISC_ENABLE));
+
+  fifo_rear = (uint8_t)-1; // Initialize register
+
+  // Route pins for pushbuttons to Logic blocks 0-3
   UI_STO_Event.set_generator(UI_STO);
-  UI_STO_Event.set_user(user::ccl0_event_a); 
+  UI_STO_Event.set_user(user::ccl0_event_a);
   UI_RCL_Event.set_generator(UI_RCL);
-  UI_RCL_Event.set_user(user::ccl1_event_a); 
+  UI_RCL_Event.set_user(user::ccl1_event_a);
   UI_REL_Event.set_generator(UI_REL);
-  UI_REL_Event.set_user(user::ccl2_event_a); 
+  UI_REL_Event.set_user(user::ccl2_event_a);
   UI_DB_Event.set_generator(UI_DB);
-  UI_DB_Event.set_user(user::ccl3_event_a); 
+  UI_DB_Event.set_user(user::ccl3_event_a);
 
   // Initialize logic block 0
-  Logic0.enable = true;         // Enable logic block 0
-  Logic0.input0 = in::event_a;  // Connect input 0 to ccl0_event_a (STO pin via UI_STO_Event)
-  //Logic0.input1 = in::event_b;  // Connect input 0 to ccl0_event_a (STO pin via UI_STO_Event)
-  Logic0.clocksource=clocksource::osc1k; //1024Hz clock
-  Logic0.filter=filter::filter; // Debounce (must be stable for 4 clock cycles)
-  Logic0.truth=0x55; //0x55;
+  Logic0.enable = true; // Enable logic block 0
+  Logic0.input0 =
+      in::event_a; // Connect input 0 to ccl0_event_a (STO pin via UI_STO_Event)
+  // Logic0.input1 = in::event_b;  // Connect input 0 to ccl0_event_a (STO pin
+  // via UI_STO_Event)
+  Logic0.clocksource = clocksource::osc1k; // 1024Hz clock
+  Logic0.filter =
+      filter::filter;  // Debounce (must be stable for 4 clock cycles)
+  Logic0.truth = 0x55; // 0x55;
   Logic0.init();
 
   // Initialize logic block 1
-  Logic1.enable = true;         // Enable logic block 0
-  Logic1.input0 = in::event_a;  // Connect input 0 to ccl1_event_a (RCL pin via UI_RCL_Event)
-  Logic1.clocksource=clocksource::osc1k; //1024Hz clock
-  Logic1.filter=filter::filter; // Debounce (must be stable for 4 clock cycles)
-  Logic1.truth=0x55;
+  Logic1.enable = true; // Enable logic block 0
+  Logic1.input0 =
+      in::event_a; // Connect input 0 to ccl1_event_a (RCL pin via UI_RCL_Event)
+  Logic1.clocksource = clocksource::osc1k; // 1024Hz clock
+  Logic1.filter =
+      filter::filter; // Debounce (must be stable for 4 clock cycles)
+  Logic1.truth = 0x55;
   Logic1.init();
 
   // Initialize logic block 2
-  Logic2.enable = true;         // Enable logic block 0
-  Logic2.input0 = in::event_a;  // Connect input 0 to ccl2_event_a (REL pin via UI_REL_Event)
-  Logic2.clocksource=clocksource::osc1k; //1024Hz clock
-  Logic2.filter=filter::filter; // Debounce (must be stable for 4 clock cycles)
-  Logic2.truth=0x55;
+  Logic2.enable = true; // Enable logic block 0
+  Logic2.input0 =
+      in::event_a; // Connect input 0 to ccl2_event_a (REL pin via UI_REL_Event)
+  Logic2.clocksource = clocksource::osc1k; // 1024Hz clock
+  Logic2.filter =
+      filter::filter; // Debounce (must be stable for 4 clock cycles)
+  Logic2.truth = 0x55;
   Logic2.init();
 
   // Initialize logic block 3
-  Logic3.enable = true;         // Enable logic block 0
-  Logic3.input0 = in::event_a;  // Connect input 0 to ccl3_event_a (DB pin via UI_DB_Event)
-  Logic3.clocksource=clocksource::osc1k; //1024Hz clock
-  Logic3.filter=filter::filter; // Debounce (must be stable for 4 clock cycles)
-  Logic3.truth=0x55;
+  Logic3.enable = true; // Enable logic block 0
+  Logic3.input0 =
+      in::event_a; // Connect input 0 to ccl3_event_a (DB pin via UI_DB_Event)
+  Logic3.clocksource = clocksource::osc1k; // 1024Hz clock
+  Logic3.filter =
+      filter::filter; // Debounce (must be stable for 4 clock cycles)
+  Logic3.truth = 0x55;
   Logic3.init();
 
-  //Event0.set_generator(gen::ccl0_out);
-  //Event0.set_user(user::evouta_pin_pa7); 
-  //Event0.start();
+  // for troubleshooting uncomment/modify the following to copy a logic block
+  // output to the built in led Event0.set_generator(gen::ccl0_out);
+  // Event0.set_user(user::evouta_pin_pa7);
+  // Event0.start();
 
+  // Start the event and logic systems
   UI_STO_Event.start();
   UI_RCL_Event.start();
   UI_REL_Event.start();
   UI_DB_Event.start();
   Logic::start();
 
+  // attach the CCL interrupts (note: this should be replaced with direct access
+  // to CCL.INTCTRL0 when dxCore Logic library supports this method
   Logic0.attachInterrupt(CCL_interrupt_handler, CHANGE);
   Logic1.attachInterrupt(CCL_interrupt_handler, CHANGE);
   Logic2.attachInterrupt(CCL_interrupt_handler, CHANGE);
   Logic3.attachInterrupt(CCL_interrupt_handler, CHANGE);
 
-  //CCL.INTCTRL0|=0b00001111; //Will replace attachInterrupt when dxCore 1.5.0 will be released...
-  //DebugOut.print(F("CCL.LUT0CTRLA=")); DebugOut.println(CCL.LUT0CTRLA, HEX);
+  // CCL.INTCTRL0|=0b00001111; //Will replace attachInterrupt when dxCore 1.5.0
+  // will be released... DebugOut.print(F("CCL.LUT0CTRLA="));
+  // DebugOut.println(CCL.LUT0CTRLA, HEX);
 
-  // Initialize buttons initial state 
-  unsigned long now = micros(); 
+  // Initialize buttons initial state. Needed to handle buttons already pressed
+  // at startup or reset (e.g. watchdog reset).
+  unsigned long now = micros();
   cli();
-  push( (UI_STO_VPORT.IN & (UI_STO_bm | UI_RCL_bm)) | (UI_REL_VPORT.IN & (UI_REL_bm | UI_DB_bm)) ); 
-  byte x = pull();
+  fifo_push((UI_STO_VPORT.IN & (UI_STO_bm | UI_RCL_bm)) |
+            (UI_REL_VPORT.IN & (UI_REL_bm | UI_DB_bm)));
+  byte x = fifo_pull();
   sei();
   initButton(0, getButtonState(x & UI_STO_bm), now);
   initButton(1, getButtonState(x & UI_RCL_bm), now);
   initButton(2, getButtonState(x & UI_REL_bm), now);
   initButton(3, getButtonState(x & UI_DB_bm), now);
   cli();
-  push( (UI_STO_VPORT.IN & (UI_STO_bm | UI_RCL_bm)) | (UI_REL_VPORT.IN & (UI_REL_bm | UI_DB_bm)) ); //Make sure we do not lose any state change  
+  fifo_push(
+      (UI_STO_VPORT.IN & (UI_STO_bm | UI_RCL_bm)) |
+      (UI_REL_VPORT.IN &
+       (UI_REL_bm | UI_DB_bm))); // Make sure we do not lose any state change
   sei();
-  
+
+  // Setup the click timer.
+  setupClicktimer();
 }
 
 /*!
@@ -316,152 +471,211 @@ void k197ButtonCluster::attachTimerInterrupts() {
    back for the relevant events
 */
 void k197ButtonCluster::checkNew() {
-   unsigned long now = micros(); 
-   for (int i=0; i<4; i++) {       
-       if (buttonState[i] == BUTTON_PRESSED_STATE) {
-           checkPressed(i, now);
-       }
-   }
-  
-   cli();
-   int8_t n=getSize();
-   bool b = isFull();
-   byte x = pull();
-   sei();
-   if (b) {
-       DebugOut.println(F("FIFO Full")); DebugOut.print(n);
-   }
-   if (x != NO_DATA) { // We have a new raw event
-       now = micros(); 
-       //DebugOut.print(F("Items=")); DebugOut.print(n);
-       //DebugOut.print(F(", fifo: 0x")); DebugOut.println(x, HEX);
-       checkNew(0, getButtonState(x & UI_STO_bm), now);
-       checkNew(1, getButtonState(x & UI_RCL_bm), now);
-       checkNew(2, getButtonState(x & UI_REL_bm), now);
-       checkNew(3, getButtonState(x & UI_DB_bm), now);
-   }
+  unsigned long now = micros();
+  for (int i = 0; i < 4; i++) {
+    if (buttonState[i] == BUTTON_PRESSED_STATE) {
+      checkPressed(i, now);
+    }
+  }
+
+  cli();
+  int8_t n = fifo_getSize();
+  bool b = fifo_isFull();
+  byte x = fifo_pull();
+  sei();
+  if (b) {
+    DebugOut.println(F("FIFO Full"));
+    DebugOut.print(n);
+  }
+  if (x != fifo_NO_DATA) { // We have a new raw event
+    now = micros();
+    // DebugOut.print(F("Items=")); DebugOut.print(n);
+    // DebugOut.print(F(", fifo: 0x")); DebugOut.println(x, HEX);
+    checkNew(0, getButtonState(x & UI_STO_bm), now);
+    checkNew(1, getButtonState(x & UI_RCL_bm), now);
+    checkNew(2, getButtonState(x & UI_REL_bm), now);
+    checkNew(3, getButtonState(x & UI_DB_bm), now);
+  }
 }
 
 /*!
     @brief  check for button events for buttons that are already pressed
 
-    @details when a button is in pressed state, LongPress and Hold events are generated if the button is hold more than the longPressTime
-    This function is used only within K197PushButton.cpp. Note that:
+    @details when a button is in pressed state, LongPress and Hold events are
+   generated if the button is hold more than the longPressTime This function is
+   used only within K197PushButton.cpp. Note that:
     - there is no check on i, so the caller must ensure it is in range
-    - the caller must ensure a button is in the pressed state before calling this function
-    Note that the button state will never change during this function call. 
+    - the caller must ensure a button is in the pressed state before calling
+   this function Note that the button state will never change during this
+   function call.
 
     @param i the array index assigned to the push button
-    @param now the current value of micros()    
+    @param now the current value of micros()
 */
-void k197ButtonCluster::checkPressed(uint8_t i, unsigned long now) {   
-    // if the button is already pressed, we handle LongPress & Hold 
-    if (now - startPressed[i] > longPressTime) {
-        if (startPressed[i] == lastHold[i]) { // 1st hold event is a LongPress
-            invoke_callback(i, UIeventLongPress);
-            lastHold[i] = now;
-        } else if (now - lastHold[i] > holdTime) { // hold event
-            invoke_callback(i, UIeventHold);
-            lastHold[i] = now;
-        }
+void k197ButtonCluster::checkPressed(uint8_t i, unsigned long now) {
+  // if the button is already pressed, we handle LongPress & Hold
+  if (now - startPressed[i] > longPressTime) {
+    if (startPressed[i] == lastHold[i]) { // 1st hold event is a LongPress
+      invoke_callback(i, UIeventLongPress);
+      lastHold[i] = now;
+    } else if (now - lastHold[i] > holdTime) { // hold event
+      invoke_callback(i, UIeventHold);
+      lastHold[i] = now;
     }
+  }
 }
 /*!
     @brief  check for button events for a specific button
 
-    @details This function is called when a new raw event is received from the HW via the FIFO
-    The function is only used only within K197PushButton.cpp. 
+    @details This function is called when a new raw event is received from the
+   HW via the FIFO The function is only used only within K197PushButton.cpp.
     that is no check on i, so the caller must ensure it is in range
 
     @param i the array index assigned to the push button
     @param btnow the current state of the button as indicated in the raw event
-    @param now the current value of micros()    
+    @param now the current value of micros()
 */
-void k197ButtonCluster::checkNew(uint8_t i, uint8_t btnow, unsigned long now) {   
-    if (btnow != buttonState[i]) { // state has changed
-        buttonState[i] = btnow;
-        // The following actions are taken at Button release
-        if (btnow == BUTTON_IDLE_STATE) { // button was just released
-            invoke_callback(i, UIeventRelease);
-            if ((now - startPressed[i]) > longPressTime) {
-                invoke_callback(i, UIeventLongClick);
-            } else if (startPressed[i] - lastReleased[i] < doubleClicktime) {
-                invoke_callback(i, UIeventClick);
-                invoke_callback(i, UIeventDoubleClick);
-            } else {
-                invoke_callback(i, UIeventClick);
-            }
-            lastReleased[i] = now;
-        } else { // btnow == BUTTON_PRESSED_STATE   // button was just pressed
-            invoke_callback(i, UIeventPress);
-            startPressed[i] = now;
-            lastHold[i] = now;
-        }
+void k197ButtonCluster::checkNew(uint8_t i, uint8_t btnow, unsigned long now) {
+  if (btnow != buttonState[i]) { // state has changed
+    buttonState[i] = btnow;
+    // The following actions are taken at Button release
+    if (btnow == BUTTON_IDLE_STATE) { // button was just released
+      invoke_callback(i, UIeventRelease);
+      if ((now - startPressed[i]) > longPressTime) {
+        invoke_callback(i, UIeventLongClick);
+      } else if (startPressed[i] - lastReleased[i] < doubleClicktime) {
+        invoke_callback(i, UIeventClick);
+        invoke_callback(i, UIeventDoubleClick);
+      } else {
+        invoke_callback(i, UIeventClick);
+      }
+      lastReleased[i] = now;
+    } else { // btnow == BUTTON_PRESSED_STATE   // button was just pressed
+      invoke_callback(i, UIeventPress);
+      startPressed[i] = now;
+      lastHold[i] = now;
     }
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////////
 // Handling of clicks for REL button
-// Note: this is the only button when this is usueful, due to the fact a double click is used to reset statistics
-// Without this part a fast double quick would be missed by the k197, as it is quite slow
 //////////////////////////////////////////////////////////////////////////////////
 
+/*!
+    @brief  setup the REL click timer
+
+    @details This function isetup a timer used to simulate button REL clicks
+   towards the K197 MB.
+
+    The reason is that we use the long press of REL to trigger the configuration
+   menu. So we need to handle this button differently. For the other buttons we
+   can mirror the press and release events directly to the K197. For the REL
+   button we do not know if the event will be a long or short press. So we need
+   to wait for the click event, and then simulate a press and release towards
+   the k197 main board. The K197 requires a button to be pressed a relatively
+   long time. Furthermore, the button must be idle for about 0.5s before a
+   second press can be recognized.
+
+    To avoid blocking processing of events for this much time, we queue the
+   button clicks and handle them via a TCA timer (for chips supporting multiple
+   TCA the timer to use is defined in pinout.h)
+*/
 void k197ButtonCluster::setupClicktimer() {
-  //Tave over and reset TCAx 
-  takeOverTCA(); // calls the appropriate dxCore function - force the core to stop using the timer and reset to the startup configuration
+  // Tave over and reset TCAx
+  takeOverTCA(); // calls the appropriate dxCore function - force the core to
+                 // stop using the timer and reset to the startup configuration
   AVR_TCA_PORT.SINGLE.CTRLA = 0x00; // Make sure the timer is disabled
-  AVR_TCA_PORT.SINGLE.CTRLESET = TCA_SINGLE_CMD_RESET_gc | 0x03; // Set CMD to RESET to do a hard reset of the timer
-  AVR_TCA_PORT.SINGLE.CTRLD = 0x00; // Make sure we are in single mode
-  AVR_TCA_PORT.SINGLE.INTCTRL = 0x00; //Disable all interrupts
-  AVR_TCA_PORT.SINGLE.INTFLAGS = TCA_SINGLE_OVF_bm | TCA_SINGLE_CMP0_bm;  // Clear interrupt flags
+  AVR_TCA_PORT.SINGLE.CTRLESET =
+      TCA_SINGLE_CMD_RESET_gc |
+      0x03; // Set CMD to RESET to do a hard reset of the timer
+  AVR_TCA_PORT.SINGLE.CTRLD = 0x00;   // Make sure we are in single mode
+  AVR_TCA_PORT.SINGLE.INTCTRL = 0x00; // Disable all interrupts
+  AVR_TCA_PORT.SINGLE.INTFLAGS =
+      TCA_SINGLE_OVF_bm | TCA_SINGLE_CMP0_bm; // Clear interrupt flags
 }
 
+/*!
+    @brief  schedule one (more) click of the REL button towards the K197 main
+   board
+
+    @details the function does not wait for the click to be completed, it
+   schedules the click and starts the timer (if not already started). In the
+   latter case interrupts are disabled for a short time (while the TCA timer is
+   started)
+
+    General Purpose Register GPIOR2 is used to speed up the interrupt handler
+*/
 void k197ButtonCluster::clickREL() {
   cli();
-  if ( (AVR_TCA_PORT.SINGLE.CTRLA & TCA_SINGLE_ENABLE_bm) == 0x00) { // We need to start the timer
-       MB_REL_VPORT.DIR |= MB_REL_bm; // Set REL pin to high
-       MB_REL_VPORT.OUT |= MB_REL_bm; // Set REL pin to output
-       //VPORTA.OUT |= 0x80;  // Turn on builtin LED
-       startClickTimer();
-       GPIOR2=0x00;
-       sei();  
-       //DebugOut.print(F("Timer started, PER=0x"));  DebugOut.print(AVR_TCA_PORT.SINGLE.PER);
-       //DebugOut.print(", CMP0="); DebugOut.println(AVR_TCA_PORT.SINGLE.CMP0);
+  if ((AVR_TCA_PORT.SINGLE.CTRLA & TCA_SINGLE_ENABLE_bm) ==
+      0x00) {                      // We need to start the timer
+    MB_REL_VPORT.DIR |= MB_REL_bm; // Set REL pin to high
+    MB_REL_VPORT.OUT |= MB_REL_bm; // Set REL pin to output
+    // VPORTA.OUT |= 0x80;  // Turn on builtin LED
+
+    AVR_TCA_PORT.SINGLE.CTRLB =
+        TCA_SINGLE_WGMODE_NORMAL_gc; // Normal mode. Disabled: Compare outputs,
+                                     // lock update.
+    AVR_TCA_PORT.SINGLE.EVCTRL &=
+        ~(TCA_SINGLE_CNTEI_bm); // Disable event counting
+    AVR_TCA_PORT.SINGLE.PER = totalCount;
+    AVR_TCA_PORT.SINGLE.CMP0 = pulseCount;
+    AVR_TCA_PORT.SINGLE.INTCTRL =
+        TCA_SINGLE_OVF_bm | TCA_SINGLE_CMP0_bm; // Enable overflow interrupt
+    AVR_TCA_PORT.SINGLE.CTRLA =
+        TCA_SINGLE_CLKSEL_DIV1024_gc |
+        TCA_SINGLE_ENABLE_bm; // enable the timer with clock DIV1024
+
+    GPIOR2 = 0x00;
+    // DebugOut.print(F("Timer started, PER=0x"));
+    // DebugOut.print(AVR_TCA_PORT.SINGLE.PER); DebugOut.print(", CMP0=");
+    // DebugOut.println(AVR_TCA_PORT.SINGLE.CMP0);
 
   } else { // engine already running
-       if (GPIOR2<REL_max_pending_clicks) {
-           GPIOR2++; // We need one (more) click
-       }
-       sei();  
-       //DebugOut.println(F("Timer already running"));
+    if (GPIOR2 < REL_max_pending_clicks) {
+      GPIOR2++; // We need one (more) click
+    }
+    // DebugOut.println(F("Timer already running"));
+  }
+  sei();
+}
+
+/*!
+    @brief  Interrupt handler, called for TCA timer overflow events
+    @details This interrupt is called after enough time is passed from the last
+   release, so that  anew press can be recognized by the k197.
+    - If more clicks are scheduled (GPIOR2>9) the MB_REL port is set to high,
+   and GPIOR2 is decremented
+    - If this was the last scheduled click (GPIOR2>9==0) the timer is stopped
+   and for good measure TCA interrupts are disabled Note that the TCA instance
+   used is defined in pinout.h
+*/
+ISR(TCA_OVF_vect) {
+  AVR_TCA_PORT.SINGLE.INTFLAGS = TCA_SINGLE_OVF_bm; // Clear flag
+  if (GPIOR2 > 0) {                // We at least one more click to generate
+    MB_REL_VPORT.DIR |= MB_REL_bm; // Set REL pin to high
+    MB_REL_VPORT.OUT |= MB_REL_bm; // Set REL pin to output
+    // VPORTA.OUT |= 0x80;  // Turn on builtin LED
+    GPIOR2--;
+  } else {                              // We stop here
+    AVR_TCA_PORT.SINGLE.INTCTRL = 0x00; // Disable all interrupts
+    AVR_TCA_PORT.SINGLE.CTRLA =
+        TCA_SINGLE_CLKSEL_DIV1024_gc; // disable the timer
   }
 }
 
-void k197ButtonCluster::startClickTimer() {
-  AVR_TCA_PORT.SINGLE.CTRLB = TCA_SINGLE_WGMODE_NORMAL_gc; // Normal mode. Disabled: Compare outputs, lock update. 
-  AVR_TCA_PORT.SINGLE.EVCTRL &= ~(TCA_SINGLE_CNTEI_bm);    // Disable event counting
-  AVR_TCA_PORT.SINGLE.PER = totalCount;
-  AVR_TCA_PORT.SINGLE.CMP0 = pulseCount;
-  AVR_TCA_PORT.SINGLE.INTCTRL = TCA_SINGLE_OVF_bm | TCA_SINGLE_CMP0_bm;         // Enable overflow interrupt
-  AVR_TCA_PORT.SINGLE.CTRLA = TCA_SINGLE_CLKSEL_DIV1024_gc | TCA_SINGLE_ENABLE_bm;  // enable the timer with clock DIV1024
-}
-
-ISR(TCA_OVF_vect) {
-   AVR_TCA_PORT.SINGLE.INTFLAGS = TCA_SINGLE_OVF_bm;  // Clear flag
-   if (GPIOR2>0) { // We at least one more click to generate
-       MB_REL_VPORT.DIR |= MB_REL_bm; // Set REL pin to high
-       MB_REL_VPORT.OUT |= MB_REL_bm; // Set REL pin to output
-       //VPORTA.OUT |= 0x80;  // Turn on builtin LED
-       GPIOR2--;
-   } else { // We stop here
-       AVR_TCA_PORT.SINGLE.INTCTRL = 0x00; //Disable all interrupts
-       AVR_TCA_PORT.SINGLE.CTRLA = TCA_SINGLE_CLKSEL_DIV1024_gc; // disable the timer      
-   }
-}
-
-ISR(TCA_CMP0_vect) {              //TCA COMPARE 0 vector
-  AVR_TCA_PORT.SINGLE.INTFLAGS = TCA_SINGLE_CMP0_bm;      // Clear flag
-  MB_REL_VPORT.DIR &= (~MB_REL_bm); // Set REL pin to input
-  MB_REL_VPORT.OUT &= (~MB_REL_bm); // Set REL pin to low
-  //VPORTA.OUT &= (~0x80);  // Turn off builtin LED
+/*!
+    @brief  Interrupt handler, called for CMP0 compare events
+    @details This interrupt is called after enough time is passed so that a
+   press is recognized by the k197. This handler simply set the port to high
+   impedence (the pulldown resistor in the k197 main board will pull the pin to
+   LOW). The timer will continue to run as we need to wait an extra "idle" time
+   before we can generate a new click (see also ISR(TCA_OVF_vect))
+*/
+ISR(TCA_CMP0_vect) {
+  AVR_TCA_PORT.SINGLE.INTFLAGS = TCA_SINGLE_CMP0_bm; // Clear flag
+  MB_REL_VPORT.DIR &= (~MB_REL_bm);                  // Set REL pin to input
+  MB_REL_VPORT.OUT &= (~MB_REL_bm);                  // Set REL pin to low
+  // VPORTA.OUT &= (~0x80);  // Turn off builtin LED
 }

--- a/K197PushButtons.cpp
+++ b/K197PushButtons.cpp
@@ -42,9 +42,6 @@ k197ButtonCluster::buttonCallBack callBack = NULL; ///< Stores the call back for
 uint8_t buttonState[] = {
     BUTTON_IDLE_STATE, BUTTON_IDLE_STATE, BUTTON_IDLE_STATE,
     BUTTON_IDLE_STATE}; ///< the current reading from the button pin
-uint8_t lastButtonState[] = {
-    BUTTON_IDLE_STATE, BUTTON_IDLE_STATE, BUTTON_IDLE_STATE,
-    BUTTON_IDLE_STATE}; ///< the previous reading from the button pin
 unsigned long startPressed[] = {0UL, 0UL, 0UL,
                                 0UL}; ///< micros() when last pressed
 unsigned long lastHold[] = {0UL, 0UL, 0UL,
@@ -208,7 +205,6 @@ inline uint8_t getButtonState(byte b) {
 
 void initButton(uint8_t i, uint8_t btnow, unsigned long now) {
     buttonState[i] = btnow;
-    lastButtonState[i] = btnow;
     startPressed[i] = now;
     lastHold[i] = now;
     lastReleased[i] = now;
@@ -385,5 +381,4 @@ void k197ButtonCluster::checkNew(uint8_t i, uint8_t btnow, unsigned long now) {
             lastHold[i] = now;
         }
     }
-    lastButtonState[i] = btnow;
 }

--- a/K197PushButtons.cpp
+++ b/K197PushButtons.cpp
@@ -328,6 +328,7 @@ void k197ButtonCluster::check(void) {
   for (unsigned int i = 0; i < (sizeof(callBack) / sizeof(callBack[0])); i++) {
     check(i);
   }
+  checkNew();
 }
 
 /*!
@@ -367,45 +368,133 @@ void k197ButtonCluster::DebugOut_printEventName(K197UIeventType event) {
   }
 }
 
+/////////////////////////////////////////////////////////////////////////
+// New implementation, interrupt based
+/////////////////////////////////////////////////////////////////////////
+
+#define NO_DATA 0xff
+//volatile static byte fifo[] {0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0};
+volatile static byte fifo[] {0,0,0,0, 0,0};
+#define NUM_FIFO_RECORDS ( sizeof(fifo) / sizeof(fifo[0]) )
+volatile int8_t front=0;
+volatile int8_t rear=-1;
+volatile int8_t items=0;
+volatile byte lastValue=0;
+
+static inline int getSize() {
+    return items;
+}
+
+static inline bool isEmpty() {
+  return (getSize() == 0);
+}
+
+static inline bool isFull() {
+  return (getSize() == NUM_FIFO_RECORDS); 
+}
+
+// Utility function to push an item at the rear of the fifo
+// No check of FIFO size because a) it should not happen b) we are going to lose clicks anyway c) the user or the WDT will recover (depending on the cause) 
+// TODO: add a way to detect and recover in pull()
+static inline void push(byte b) { 
+    rear = (rear + 1) % NUM_FIFO_RECORDS;
+    fifo[rear] = b;
+    (++items % NUM_FIFO_RECORDS);
+}
+
+// Utility function to pull the item at the front of the fifo
+static inline byte pull() {
+  if (isEmpty()) return NO_DATA;
+  byte x = fifo[front];
+  front = (front + 1) % NUM_FIFO_RECORDS;
+  items--;
+  return x;  
+}
+
+// Interrupt handler for the CCL vector. Whatever the CCL causing the event, we push a copy of the pushbutton pins to the fifo queue 
+// This should work in dxCore 1.5.0 when it is released...
+//ISR(CCL_CCL_vect) {
+
+//Normal function, required with current release of dxCore
+void CCL_interrupt_handler() {
+ //CCL.INTFLAGS =  CCL.INTFLAGS; // We prefer to enter the interrupts twice rather than missing an event
+ push( (UI_STO_VPORT.IN & (UI_STO_bm | UI_RCL_bm)) | (UI_REL_VPORT.IN & (UI_REL_bm | UI_DB_bm)) ); 
+}
+
 void k197ButtonCluster::attachTimerInterrupts() {
   // Route pins for pushbuttons to Logic block 0 & 1
   UI_STO_Event.set_generator(UI_STO);
-  UI_RCL_Event.set_generator(UI_RCL);
   UI_STO_Event.set_user(user::ccl0_event_a); 
-  UI_RCL_Event.set_user(user::ccl0_event_b); 
-
+  UI_RCL_Event.set_generator(UI_RCL);
+  UI_RCL_Event.set_user(user::ccl1_event_a); 
   UI_REL_Event.set_generator(UI_REL);
+  UI_REL_Event.set_user(user::ccl2_event_a); 
   UI_DB_Event.set_generator(UI_DB);
-  UI_REL_Event.set_user(user::ccl1_event_a); 
-  UI_DB_Event.set_user(user::ccl1_event_b); 
+  UI_DB_Event.set_user(user::ccl3_event_a); 
 
   // Initialize logic block 0
   Logic0.enable = true;         // Enable logic block 0
   Logic0.input0 = in::event_a;  // Connect input 0 to ccl0_event_a (STO pin via UI_STO_Event)
-  Logic0.input1 = in::event_b;  // Connect input 0 to ccl0_event_b (STO pin via UI_STO_Event)
-  // input 2 default = unused TODO: use as clock + 
+  //Logic0.input1 = in::event_b;  // Connect input 0 to ccl0_event_a (STO pin via UI_STO_Event)
   Logic0.clocksource=clocksource::osc1k; //1024Hz clock
-  Logic0.filter=filter::disable; // Debounce (must be stable for 4 clock cycles)
-  Logic0.truth=0x77;
+  Logic0.filter=filter::filter; // Debounce (must be stable for 4 clock cycles)
+  Logic0.truth=0x55; //0x77;
   Logic0.init();
 
   // Initialize logic block 1
   Logic1.enable = true;         // Enable logic block 0
-  Logic1.input0 = in::event_a;  // Connect input 0 to ccl0_event_a (STO pin via UI_STO_Event)
-  Logic1.input1 = in::event_b;  // Connect input 0 to ccl0_event_b (STO pin via UI_STO_Event)
-  // input 2 default = unused TODO: use as clock + 
+  Logic1.input0 = in::event_a;  // Connect input 0 to ccl1_event_a (RCL pin via UI_RCL_Event)
   Logic1.clocksource=clocksource::osc1k; //1024Hz clock
-  Logic1.filter=filter::disable; // Debounce (must be stable for 4 clock cycles)
-  Logic1.truth=0x77;
+  Logic1.filter=filter::filter; // Debounce (must be stable for 4 clock cycles)
+  Logic1.truth=0x55;
   Logic1.init();
 
-  Event0.set_generator(gen::ccl1_out);
-  Event0.set_user(user::evouta_pin_pa7); 
+  // Initialize logic block 2
+  Logic2.enable = true;         // Enable logic block 0
+  Logic2.input0 = in::event_a;  // Connect input 0 to ccl2_event_a (REL pin via UI_REL_Event)
+  Logic2.clocksource=clocksource::osc1k; //1024Hz clock
+  Logic2.filter=filter::filter; // Debounce (must be stable for 4 clock cycles)
+  Logic2.truth=0x55;
+  Logic2.init();
+
+  // Initialize logic block 3
+  Logic3.enable = true;         // Enable logic block 0
+  Logic3.input0 = in::event_a;  // Connect input 0 to ccl3_event_a (DB pin via UI_DB_Event)
+  Logic3.clocksource=clocksource::osc1k; //1024Hz clock
+  Logic3.filter=filter::filter; // Debounce (must be stable for 4 clock cycles)
+  Logic3.truth=0x55;
+  Logic3.init();
+
+  //Event0.set_generator(gen::ccl0_out);
+  //Event0.set_user(user::evouta_pin_pa7); 
+  //Event0.start();
 
   UI_STO_Event.start();
   UI_RCL_Event.start();
   UI_REL_Event.start();
   UI_DB_Event.start();
   Logic::start();
-  Event0.start();
+
+  Logic0.attachInterrupt(CCL_interrupt_handler, CHANGE);
+  Logic1.attachInterrupt(CCL_interrupt_handler, CHANGE);
+  Logic2.attachInterrupt(CCL_interrupt_handler, CHANGE);
+  Logic3.attachInterrupt(CCL_interrupt_handler, CHANGE);
+
+  //CCL.INTCTRL0|=0b00001111; //Will replace attachInterrupt when dxCore 1.5.0 will be released...
+  //DebugOut.print(F("CCL.LUT0CTRLA=")); DebugOut.println(CCL.LUT0CTRLA, HEX);
+}
+
+void k197ButtonCluster::checkNew() {
+   cli();
+   int8_t n=items;
+   bool b = isFull();
+   byte x = pull();
+   sei();
+   if (b) {
+       DebugOut.println(F("<========== FIFO is Full !!! ================>")); DebugOut.print(n);
+   }
+   if (x != NO_DATA) {
+       DebugOut.print(F("Items=")); DebugOut.print(n);
+       DebugOut.print(F(", fifo: 0x")); DebugOut.println(x, HEX);
+   }
 }

--- a/K197PushButtons.cpp
+++ b/K197PushButtons.cpp
@@ -549,10 +549,12 @@ void k197ButtonCluster::checkNew(uint8_t i, uint8_t btnow, unsigned long now) {
       } else if (startPressed[i] - lastReleased[i] < doubleClicktime) {
         invoke_callback(i, UIeventClick);
         invoke_callback(i, UIeventDoubleClick);
-        //DebugOut.print(F("Dbclick time: ")); DebugOut.println(now-lastReleased[i]);
+        // DebugOut.print(F("Dbclick time: "));
+        // DebugOut.println(now-lastReleased[i]);
       } else {
         invoke_callback(i, UIeventClick);
-        //DebugOut.print(F("Click time: ")); DebugOut.println(now-startPressed[i]);
+        // DebugOut.print(F("Click time: "));
+        // DebugOut.println(now-startPressed[i]);
       }
       lastReleased[i] = now;
     } else { // btnow == BUTTON_PRESSED_STATE   // button was just pressed
@@ -607,7 +609,7 @@ void k197ButtonCluster::setupClicktimer() {
     @details the function does not wait for the click to be completed, it
    schedules the click and starts the timer (if not already started). In the
    latter case interrupts are disabled for a short time (while the TCA timer is
-   started). 
+   started).
    There is a delay of a full timer cycle before the first click. This is by
    design, so that a double click can cancel the scheduled clicks to
    perform an alternative action
@@ -615,14 +617,15 @@ void k197ButtonCluster::setupClicktimer() {
     General Purpose Register GPIOR2 is used to speed up the interrupt handler
 */
 void k197ButtonCluster::clickREL() {
-  if (GPIOR2 > REL_max_pending_clicks) return;
+  if (GPIOR2 > REL_max_pending_clicks)
+    return;
   cli();
   GPIOR2++;
   if ((AVR_TCA_PORT.SINGLE.CTRLA & TCA_SINGLE_ENABLE_bm) ==
-      0x00) {                      // We need to start the timer
-    //MB_REL_VPORT.DIR |= MB_REL_bm; // Set REL pin to high
-    //MB_REL_VPORT.OUT |= MB_REL_bm; // Set REL pin to output
-    // VPORTA.OUT |= 0x80;  // Turn on builtin LED
+      0x00) { // We need to start the timer
+    // MB_REL_VPORT.DIR |= MB_REL_bm; // Set REL pin to high
+    // MB_REL_VPORT.OUT |= MB_REL_bm; // Set REL pin to output
+    //  VPORTA.OUT |= 0x80;  // Turn on builtin LED
 
     AVR_TCA_PORT.SINGLE.CTRLB =
         TCA_SINGLE_WGMODE_NORMAL_gc; // Normal mode. Disabled: Compare outputs,
@@ -652,15 +655,14 @@ void k197ButtonCluster::clickREL() {
     @brief  cancel all the REL button clicks that may have been scheduled
    board
 
-    @details the function reset the counter, which will prevent any new click to be initiated
-    Any simulated presses already ongoing are not affected, but no new click will be initiated thereafter  
+    @details the function reset the counter, which will prevent any new click to
+   be initiated Any simulated presses already ongoing are not affected, but no
+   new click will be initiated thereafter
 
-    General Purpose Register GPIOR2 is used to speed up the interrupt handler (see also clickREL())
+    General Purpose Register GPIOR2 is used to speed up the interrupt handler
+   (see also clickREL())
 */
-void k197ButtonCluster::cancelClickREL() {
-  GPIOR2 = 0x00;
-}
-
+void k197ButtonCluster::cancelClickREL() { GPIOR2 = 0x00; }
 
 /*!
     @brief  Interrupt handler, called for TCA timer overflow events

--- a/K197PushButtons.h
+++ b/K197PushButtons.h
@@ -40,58 +40,54 @@ public:
   k197ButtonCluster(){}; ///< default constructor
   typedef void (*buttonCallBack)(
       K197UIeventsource eventSource,
-      K197UIeventType
-          eventType); ///< define the type of the callback function
+      K197UIeventType eventType); ///< define the type of the callback function
   void setup();
 
 protected:
-  void check(uint8_t i);
   void checkNew(uint8_t i, uint8_t btnow, unsigned long now);
   void checkPressed(uint8_t i, unsigned long now);
 
   static const unsigned long longPressTime =
       500000L; ///< long press event will be generated when pressed more than
-            ///< longPressTime us
+               ///< longPressTime us
   static const unsigned long holdTime =
-      200000L; ///< After a LongPress Hold events will be generated every holdTime 
-               ///< in us while the button is still pressed
+      200000L; ///< After a LongPress Hold events will be generated every
+               ///< holdTime in us while the button is still pressed
   static const unsigned long doubleClicktime =
-      500000L; ///< double click event when pressed within doubleClicktime us from
-            ///< a previous release
+      500000L; ///< double click event when pressed within doubleClicktime us
+               ///< from a previous release
 
   // click generator for REL key
-  static const uint16_t pulseCount =   750; // REL click pulse (750=>32 ms) 
-  static const uint16_t totalCount = 15000; // REL click pulse+wait (15000=>640 ms) 
+  static const uint16_t pulseCount = 750; ///< REL click pulse (750=>32 ms)
+  static const uint16_t totalCount =
+      15000; ///< REL click pulse+idle time (15000=>640 ms)
   static const uint8_t REL_max_pending_clicks =
       4; ///< maximum number of REL button clicks that can be queued
-      
-  void attachTimerInterrupts();
+
   void setupClicktimer();
-  void startClickTimer();
 
 public:
-  void setCallback(buttonCallBack pinCallBack);
+  void setCallback(buttonCallBack clusterCallBack);
   void checkNew();
   bool isPressed(K197UIeventsource eventSource);
 
-  
   /*!
       @brief  check if two buttons are pressed simultaneously
       @param btn1 the event source value corresponding to the first button
       @param btn2 the event source value corresponding to the second button
-      @return true if the two buttons are pressed simultaneously, false otherwise
+      @return true if the two buttons are pressed simultaneously, false
+     otherwise
   */
   bool isSimultaneousPress(K197UIeventsource btn1, K197UIeventsource btn2) {
-      if (isPressed(btn1) && isPressed(btn2)) {
-         return true;
-      }
-      return false;
+    if (isPressed(btn1) && isPressed(btn2)) {
+      return true;
+    }
+    return false;
   }
 
   static void DebugOut_printEventName(K197UIeventType event);
 
   void clickREL();
-  
 };
 
 #endif //__ABUTTON_H

--- a/K197PushButtons.h
+++ b/K197PushButtons.h
@@ -60,8 +60,11 @@ protected:
       500000L; ///< double click event when pressed within doubleClicktime us from
             ///< a previous release
   bool transparentMode = true; ///< true when in transparent mode
-  void attachInterrupts();
-  void detachInterrupts();
+  void attachPinInterrupts();
+  void detachPinInterrupts();
+
+  void attachTimerInterrupts();
+
 
 public:
   bool setCallback(K197UIeventsource eventSource, buttonCallBack pinCallBack);

--- a/K197PushButtons.h
+++ b/K197PushButtons.h
@@ -46,6 +46,9 @@ public:
 
 protected:
   void check(uint8_t i);
+  void checkPressed(uint8_t i, unsigned long now);
+  void checkNew(uint8_t i, uint8_t btnow, unsigned long now);
+
   static const unsigned long debounceDelay =
       500L; ///< the debounce time us; decrease if the button is not responsive
          ///< enough, increase in case you experience unintended double
@@ -68,7 +71,6 @@ protected:
 
 public:
   bool setCallback(K197UIeventsource eventSource, buttonCallBack pinCallBack);
-
   void check();
   void checkNew();
 

--- a/K197PushButtons.h
+++ b/K197PushButtons.h
@@ -58,13 +58,12 @@ protected:
   static const unsigned long doubleClicktime =
       500000L; ///< double click event when pressed within doubleClicktime us from
             ///< a previous release
-
   void attachTimerInterrupts();
-
 
 public:
   void setCallback(buttonCallBack pinCallBack);
   void checkNew();
+  bool isPressed(K197UIeventsource eventSource);
 
   static void DebugOut_printEventName(K197UIeventType event);
 };

--- a/K197PushButtons.h
+++ b/K197PushButtons.h
@@ -88,6 +88,9 @@ public:
   static void DebugOut_printEventName(K197UIeventType event);
 
   void clickREL();
+  void cancelClickREL();
 };
+
+extern k197ButtonCluster pushbuttons;
 
 #endif //__ABUTTON_H

--- a/K197PushButtons.h
+++ b/K197PushButtons.h
@@ -58,9 +58,6 @@ protected:
   static const unsigned long doubleClicktime =
       500000L; ///< double click event when pressed within doubleClicktime us from
             ///< a previous release
-  bool transparentMode = false; ///< true when in transparent mode
-  void attachPinInterrupts();
-  void detachPinInterrupts();
 
   void attachTimerInterrupts();
 
@@ -70,15 +67,6 @@ public:
   void checkNew();
 
   static void DebugOut_printEventName(K197UIeventType event);
-
-  /*!
-      @brief  check if transparent mode is enabled (see setTransparentMode() for
-     more information)
-      @return true if transparent mode is enabled
-     "Err", "0L", etc.)
-  */
-  bool isTransparentMode() { return transparentMode; };
-  void setTransparentMode(bool newMode);
 };
 
 #endif //__ABUTTON_H

--- a/K197PushButtons.h
+++ b/K197PushButtons.h
@@ -65,6 +65,20 @@ public:
   void checkNew();
   bool isPressed(K197UIeventsource eventSource);
 
+  
+  /*!
+      @brief  check if two buttons are pressed simultaneously
+      @param btn1 the event source value corresponding to the first button
+      @param btn2 the event source value corresponding to the second button
+      @return true if the two buttons are pressed simultaneously, false otherwise
+  */
+  bool isSimultaneousPress(K197UIeventsource btn1, K197UIeventsource btn2) {
+      if (isPressed(btn1) && isPressed(btn2)) {
+         return true;
+      }
+      return false;
+  }
+
   static void DebugOut_printEventName(K197UIeventType event);
 };
 

--- a/K197PushButtons.h
+++ b/K197PushButtons.h
@@ -58,7 +58,16 @@ protected:
   static const unsigned long doubleClicktime =
       500000L; ///< double click event when pressed within doubleClicktime us from
             ///< a previous release
+
+  // click generator for REL key
+  static const uint16_t pulseCount =   750; // REL click pulse (750=>32 ms) 
+  static const uint16_t totalCount = 15000; // REL click pulse+wait (15000=>640 ms) 
+  static const uint8_t REL_max_pending_clicks =
+      4; ///< maximum number of REL button clicks that can be queued
+      
   void attachTimerInterrupts();
+  void setupClicktimer();
+  void startClickTimer();
 
 public:
   void setCallback(buttonCallBack pinCallBack);
@@ -80,6 +89,9 @@ public:
   }
 
   static void DebugOut_printEventName(K197UIeventType event);
+
+  void clickREL();
+  
 };
 
 #endif //__ABUTTON_H

--- a/K197PushButtons.h
+++ b/K197PushButtons.h
@@ -69,7 +69,8 @@ protected:
 public:
   bool setCallback(K197UIeventsource eventSource, buttonCallBack pinCallBack);
 
-  void check(void);
+  void check();
+  void checkNew();
 
   static void DebugOut_printEventName(K197UIeventType event);
 

--- a/K197PushButtons.h
+++ b/K197PushButtons.h
@@ -46,13 +46,9 @@ public:
 
 protected:
   void check(uint8_t i);
-  void checkPressed(uint8_t i, unsigned long now);
   void checkNew(uint8_t i, uint8_t btnow, unsigned long now);
+  void checkPressed(uint8_t i, unsigned long now);
 
-  static const unsigned long debounceDelay =
-      500L; ///< the debounce time us; decrease if the button is not responsive
-         ///< enough, increase in case you experience unintended double
-         ///< presses
   static const unsigned long longPressTime =
       500000L; ///< long press event will be generated when pressed more than
             ///< longPressTime us
@@ -70,8 +66,7 @@ protected:
 
 
 public:
-  bool setCallback(K197UIeventsource eventSource, buttonCallBack pinCallBack);
-  void check();
+  void setCallback(buttonCallBack pinCallBack);
   void checkNew();
 
   static void DebugOut_printEventName(K197UIeventType event);

--- a/K197PushButtons.h
+++ b/K197PushButtons.h
@@ -58,7 +58,7 @@ protected:
   static const unsigned long doubleClicktime =
       500000L; ///< double click event when pressed within doubleClicktime us from
             ///< a previous release
-  bool transparentMode = true; ///< true when in transparent mode
+  bool transparentMode = false; ///< true when in transparent mode
   void attachPinInterrupts();
   void detachPinInterrupts();
 

--- a/K197device.cpp
+++ b/K197device.cpp
@@ -187,12 +187,17 @@ byte K197device::getNewReading(byte *data) {
     msg_value = getMsgValue(message, K197_MSG_SIZE);
     msg_is_ovrange = false;
   } else {
-    if (strstr(message, "0L") != NULL) {
+    //if (strstr(message, "0L") != NULL) {/
+    if (strcasecmp_P(message, PSTR("0L")) == 0) {
       msg_is_ovrange = true;
     } else {
       msg_is_ovrange = false;
     }
     msg_value = 0.0;
+    if (strncmp_P(message, PSTR(" CAL"), 4) == 0) {
+        annunciators8 |= K197_Cal_bm;
+        DebugOut.println(F(" CAL found!"));
+    }
   }
   if (isTKModeActive() && msg_is_num) {
     tkConvertV2C();
@@ -297,6 +302,13 @@ void K197device::debugPrint() {
     DebugOut.print(F(", ("));
     DebugOut.print(msg_value, 6);
     DebugOut.print(')');
+  } else {
+    for (int i=0; i< K197_MSG_SIZE; i++) {
+        DebugOut.print(F(" 0x")); 
+        if (message[i]<0x10) DebugOut.print('0');
+        DebugOut.print(message[i], HEX);
+    }
+    DebugOut.println();
   }
   if (msg_is_ovrange)
     DebugOut.print(F(" + Ov.Range"));

--- a/K197device.cpp
+++ b/K197device.cpp
@@ -187,7 +187,7 @@ byte K197device::getNewReading(byte *data) {
     msg_value = getMsgValue(message, K197_MSG_SIZE);
     msg_is_ovrange = false;
   } else {
-    //if (strstr(message, "0L") != NULL) {/
+    // if (strstr(message, "0L") != NULL) {/
     if (strcasecmp_P(message, PSTR("0L")) == 0) {
       msg_is_ovrange = true;
     } else {
@@ -195,8 +195,8 @@ byte K197device::getNewReading(byte *data) {
     }
     msg_value = 0.0;
     if (strncmp_P(message, PSTR(" CAL"), 4) == 0) {
-        annunciators8 |= K197_Cal_bm;
-        DebugOut.println(F(" CAL found!"));
+      annunciators8 |= K197_Cal_bm;
+      DebugOut.println(F(" CAL found!"));
     }
   }
   if (isTKModeActive() && msg_is_num) {
@@ -303,26 +303,28 @@ void K197device::debugPrint() {
     DebugOut.print(msg_value, 6);
     DebugOut.print(')');
   } else {
-    for (int i=0; i< K197_MSG_SIZE; i++) {
-        DebugOut.print(F(" 0x")); 
-        if (message[i]<0x10) DebugOut.print('0');
-        DebugOut.print(message[i], HEX);
+    for (int i = 0; i < K197_MSG_SIZE; i++) {
+      DebugOut.print(F(" 0x"));
+      if (message[i] < 0x10)
+        DebugOut.print('0');
+      DebugOut.print(message[i], HEX);
     }
     DebugOut.println();
   }
   if (msg_is_ovrange)
     DebugOut.print(F(" + Ov.Range"));
   DebugOut.println();
-} 
+}
 
 /*!
-    @brief  utility function, used to compare two set of annunciator0, ignoring the minus sign in the comparison
+    @brief  utility function, used to compare two set of annunciator0, ignoring
+   the minus sign in the comparison
     @param b1 first annunciator0 set
     @param b2 second annunciator0 set
     @details average, max and min are calculated here
  */
 static inline bool change0(byte b1, byte b2) {
-   return (b1&(~K197_MINUS_bm)) != (b2&(~K197_MINUS_bm));
+  return (b1 & (~K197_MINUS_bm)) != (b2 & (~K197_MINUS_bm));
 }
 
 /*!
@@ -333,7 +335,7 @@ void K197device::updateCache() {
   if (cache.tkMode != tkMode || change0(cache.annunciators0, annunciators0) ||
       cache.annunciators7 != annunciators7 ||
       cache.annunciators8 != annunciators8) { // Something changed, reset stats
-        resetStatistics();
+    resetStatistics();
   } else {
     cache.average += (msg_value - cache.average) /
                      float(cache.nsamples); // This not perfect but good enough
@@ -356,11 +358,7 @@ void K197device::updateCache() {
     @details average, max and min are calculated here
  */
 void K197device::resetStatistics() {
-    cache.average = msg_value;
-    cache.min = msg_value;
-    cache.max = msg_value;  
-}
-
-void setCalibrationMode() {
-    
+  cache.average = msg_value;
+  cache.min = msg_value;
+  cache.max = msg_value;
 }

--- a/K197device.cpp
+++ b/K197device.cpp
@@ -348,3 +348,7 @@ void K197device::resetStatistics() {
     cache.min = msg_value;
     cache.max = msg_value;  
 }
+
+void setCalibrationMode() {
+    
+}

--- a/K197device.h
+++ b/K197device.h
@@ -342,12 +342,16 @@ public:
       @brief  test if CAL is on
       @return returns true if on, false otherwise
   */
-  inline bool isCal() { return (annunciators8 & K197_Cal_bm) != 0; };
+  inline bool isCal() { 
+    if ( (annunciators8 & K197_Cal_bm) != 0 )
+        return true;
+    return false;
+  }
   /*!
       @brief  test if CAL is off
       @return returns true if off, false otherwise
   */
-  inline bool isNotCal() { return (annunciators8 & K197_Cal_bm) == 0; };
+  inline bool isNotCal() { return !isCal(); };
   /*!
       @brief  test if "Ω" is on
       @return returns true if on, false otherwise

--- a/K197device.h
+++ b/K197device.h
@@ -344,6 +344,11 @@ public:
   */
   inline bool isCal() { return (annunciators8 & K197_Cal_bm) != 0; };
   /*!
+      @brief  test if CAL is off
+      @return returns true if off, false otherwise
+  */
+  inline bool isNotCal() { return (annunciators8 & K197_Cal_bm) == 0; };
+  /*!
       @brief  test if "Ω" is on
       @return returns true if on, false otherwise
   */

--- a/K197device.h
+++ b/K197device.h
@@ -342,9 +342,9 @@ public:
       @brief  test if CAL is on
       @return returns true if on, false otherwise
   */
-  inline bool isCal() { 
-    if ( (annunciators8 & K197_Cal_bm) != 0 )
-        return true;
+  inline bool isCal() {
+    if ((annunciators8 & K197_Cal_bm) != 0)
+      return true;
     return false;
   }
   /*!

--- a/UIevents.h
+++ b/UIevents.h
@@ -34,9 +34,9 @@
     - Press-Release-Click
     - Press-Release-LongPress-Release-Longclick (if hold for a longer time)
 
-    A second click event close to the first will generate a double click event right after the second click event
-    Hold is generated after LongPress and before Release (if pressed for a
-   sufficiently long time)
+    A second click event close to the first will generate a double click event
+   right after the second click event Hold is generated after LongPress and
+   before Release (if pressed for a sufficiently long time)
 */
 /**************************************************************************/
 
@@ -59,7 +59,7 @@ enum K197UIeventType {
 /**************************************************************************/
 enum K197UIeventsource {
   K197key_REL = UI_REL, ///< REL key (Alt. functions: up)
-  K197key_DB = UI_DB,  ///< DB key  (Alt. functions: down,   mode)
+  K197key_DB = UI_DB,   ///< DB key  (Alt. functions: down,   mode)
   K197key_STO =
       UI_STO, ///< STO key (Alt. functions: clear, cancel, decrease, left)
   K197key_RCL = UI_RCL, ///< RCL key (Alt. functions: set, Ok, increase, right)

--- a/UImanager.cpp
+++ b/UImanager.cpp
@@ -31,10 +31,10 @@
   Fonts used in the application:
     u8g2_font_5x7_mr  ==> terminal window, local T, Bluetooth status
     u8g2_font_6x12_mr ==> BAT, all menus
-    u8g2_font_8x13_mr ==> AUTO, REL, dB, STO, RCL, Cal, RMT, most annunciators in split screen
-    u8g2_font_9x15_m_symbols ==> meas. unit, AC, Split screen: message, AC
-    u8g2_font_inr30_mr ==> main message
-    u8g2_font_inr16_mr ==> main message in minmax mode
+    u8g2_font_8x13_mr ==> AUTO, REL, dB, STO, RCL, Cal, RMT, most annunciators
+  in split screen u8g2_font_9x15_m_symbols ==> meas. unit, AC, Split screen:
+  message, AC u8g2_font_inr30_mr ==> main message u8g2_font_inr16_mr ==> main
+  message in minmax mode
 
     mr ==> monospace restricted
     m ==> monospace
@@ -108,17 +108,17 @@ void setup_draw(void) {
   u8g2.setFontRefHeightExtendedText();
   u8g2.setFontDirection(0);
 
-/*
-  u8g2.setFont(u8g2_font_inr16_mr);
-  DebugOut.print(F("Disp. H="));
-  DebugOut.print(u8g2.getDisplayHeight());
-  DebugOut.print(F(", font h="));
-  DebugOut.print(u8g2.getAscent());
-  DebugOut.print(F("/"));
-  DebugOut.print(u8g2.getDescent());
-  DebugOut.print(F("/"));
-  DebugOut.println(u8g2.getMaxCharHeight());
-*/
+  /*
+    u8g2.setFont(u8g2_font_inr16_mr);
+    DebugOut.print(F("Disp. H="));
+    DebugOut.print(u8g2.getDisplayHeight());
+    DebugOut.print(F(", font h="));
+    DebugOut.print(u8g2.getAscent());
+    DebugOut.print(F("/"));
+    DebugOut.print(u8g2.getDescent());
+    DebugOut.print(F("/"));
+    DebugOut.println(u8g2.getMaxCharHeight());
+  */
   dxUtil.checkFreeStack();
 }
 
@@ -167,9 +167,12 @@ void UImanager::setup() {
    to setup();
 */
 void UImanager::updateDisplay() {
-  if ( k197dev.isNotCal() && isSplitScreen()) updateSplitScreen();
-  else if ( k197dev.isCal() || (getScreenMode() == K197sc_normal) ) updateNormalScreen();
-  else updateMinMaxScreen();
+  if (k197dev.isNotCal() && isSplitScreen())
+    updateSplitScreen();
+  else if (k197dev.isCal() || (getScreenMode() == K197sc_normal))
+    updateNormalScreen();
+  else
+    updateMinMaxScreen();
   dxUtil.checkFreeStack();
 }
 
@@ -228,7 +231,7 @@ void UImanager::updateSplitScreen() {
   else
     u8g2.print(F("      "));
 
-  if ( isSplitScreen() && !isMenuVisible() ) { // Show the debug log
+  if (isSplitScreen() && !isMenuVisible()) { // Show the debug log
     u8g2.setFont(u8g2_font_5x7_mr); // set the font for the terminal window
     u8g2.drawLog(0, 0, u8g2log);    // draw the terminal window on the display
   } else { // For all other modes we show the settings menu when in split mode
@@ -239,7 +242,8 @@ void UImanager::updateSplitScreen() {
 }
 
 /*!
-    @brief  update the display, used when in normal screen mode. See also updateDisplay().
+    @brief  update the display, used when in normal screen mode. See also
+   updateDisplay().
 */
 void UImanager::updateNormalScreen() {
   u8g2.setFont(
@@ -358,12 +362,14 @@ void UImanager::updateNormalScreen() {
 }
 
 /*!
-    @brief  update the display, used when in minmax screen mode. See also updateDisplay().
+    @brief  update the display, used when in minmax screen mode. See also
+   updateDisplay().
 */
 void UImanager::updateMinMaxScreen() {
   u8g2.setFont(
       u8g2_font_inr16_mr); // width =25  points (7 characters=175 points)
-  const unsigned int xraw = 130; const unsigned int yraw = 15;
+  const unsigned int xraw = 130;
+  const unsigned int yraw = 15;
   const unsigned int dpsz_x = 3;  // decimal point size in x direction
   const unsigned int dpsz_y = 3;  // decimal point size in y direction
   const unsigned int dphsz_x = 2; // decimal point "half size" in x direction
@@ -397,7 +403,8 @@ void UImanager::updateMinMaxScreen() {
 
   // set the other announciators
   u8g2.setFont(u8g2_font_6x12_mr);
-  unsigned int x = 0; unsigned int y = 5; 
+  unsigned int x = 0;
+  unsigned int y = 5;
   u8g2.setCursor(x, y);
   if (k197dev.isREL())
     u8g2.print(F("REL"));
@@ -406,17 +413,32 @@ void UImanager::updateMinMaxScreen() {
 
   // Write Min/average/Max labels
   u8g2.setFont(u8g2_font_5x7_mr);
-  x = u8g2.tx+10; y = 5; u8g2.setCursor(x, y); u8g2.print(F("Max "));
-  y += char_height_9x15; u8g2.setCursor(x, y); u8g2.print(F("Avg "));
-  y += char_height_9x15; u8g2.setCursor(x, y); u8g2.print(F("Min "));
+  x = u8g2.tx + 10;
+  y = 5;
+  u8g2.setCursor(x, y);
+  u8g2.print(F("Max "));
+  y += char_height_9x15;
+  u8g2.setCursor(x, y);
+  u8g2.print(F("Avg "));
+  y += char_height_9x15;
+  u8g2.setCursor(x, y);
+  u8g2.print(F("Min "));
 
   u8g2.setFont(u8g2_font_9x15_m_symbols);
   char buf[K197_MSG_SIZE];
-  x = u8g2.tx; y = 3;    u8g2.setCursor(x, y); u8g2.print(formatNumber(buf, k197dev.getMax()));
-  y += char_height_9x15; u8g2.setCursor(x, y); u8g2.print(formatNumber(buf, k197dev.getAverage()));
-  y += char_height_9x15; u8g2.setCursor(x, y); u8g2.print(formatNumber(buf, k197dev.getMin()));
+  x = u8g2.tx;
+  y = 3;
+  u8g2.setCursor(x, y);
+  u8g2.print(formatNumber(buf, k197dev.getMax()));
+  y += char_height_9x15;
+  u8g2.setCursor(x, y);
+  u8g2.print(formatNumber(buf, k197dev.getAverage()));
+  y += char_height_9x15;
+  u8g2.setCursor(x, y);
+  u8g2.print(formatNumber(buf, k197dev.getMin()));
 
-  x = 170; y = 2;
+  x = 170;
+  y = 2;
   u8g2.setCursor(x, y);
   u8g2.setFont(u8g2_font_5x7_mr);
   if (k197dev.isTKModeActive()) { // Display local temperature
@@ -438,8 +460,8 @@ void UImanager::updateMinMaxScreen() {
    @details  Three modes are defined: normal mode, menu mode and debug mode.
    In debug and menu mode the measurements are displays on the right of the
    screen (split screen), while the left part is reserved for debug messages and
-   menu items respectively. Normal mode is a fulol screen mode equivalent to the original K197 display. 
-   As the name suggest debug mode is intended for
+   menu items respectively. Normal mode is a fulol screen mode equivalent to the
+   original K197 display. As the name suggest debug mode is intended for
    debugging the code that interacts with the serial port/bluetooth module
    itself, so that Serial cannot be used.
 
@@ -447,19 +469,25 @@ void UImanager::updateMinMaxScreen() {
    respectively
 */
 void UImanager::setScreenMode(K197screenMode mode) {
-  screen_mode = (K197screenMode) (screen_mode & K197sc_AttributesBitMask) ; // clear current screen mode
-  screen_mode = (K197screenMode) (screen_mode | (mode & K197sc_ScreenModeMask)) ; // set the mode bits to enter the new mode
+  screen_mode =
+      (K197screenMode)(screen_mode &
+                       K197sc_AttributesBitMask); // clear current screen mode
+  screen_mode =
+      (K197screenMode)(screen_mode |
+                       (mode & K197sc_ScreenModeMask)); // set the mode bits to
+                                                        // enter the new mode
   clearScreen();
 }
 
 /*!
   @brief clear the display
-  @details This is done automatically when the screen mode changes, there should be no need to call this function elsewhere
+  @details This is done automatically when the screen mode changes, there should
+  be no need to call this function elsewhere
 */
 void UImanager::clearScreen() {
-  //DebugOut.print(F("screen_mode=")); DebugOut.println(screen_mode, HEX);
+  // DebugOut.print(F("screen_mode=")); DebugOut.println(screen_mode, HEX);
   u8g2.clearBuffer();
-  u8g2.sendBuffer();  
+  u8g2.sendBuffer();
   dxUtil.checkFreeStack();
 }
 
@@ -470,8 +498,9 @@ void UImanager::clearScreen() {
       @param connected true if a BT connection is detected, false otherwise
 */
 void UImanager::updateBtStatus() {
-  if (isSplitScreen() || (getScreenMode() != K197sc_normal) ) { //Note: No BT status in cal mode
-      return;
+  if (isSplitScreen() ||
+      (getScreenMode() != K197sc_normal)) { // Note: No BT status in cal mode
+    return;
   }
   unsigned int x = 95;
   unsigned int y = 2;
@@ -520,7 +549,7 @@ DEF_MENU_BUTTON(reloadSettings, 15,
                 "Reload settings"); ///< TBD: submenu not yet implemented
 DEF_MENU_ACTION(openLog, 15, "Show log",
                 dxUtil.reportStack();
-                uiman.showDebugLog();); ///< show debug log
+                DebugOut.println(); uiman.showDebugLog();); ///< show debug log
 
 UImenuItem *mainMenuItems[] = {
     &mainSeparator0, &additionalModes, &reassignStoRcl, &btDatalog,
@@ -557,13 +586,16 @@ UImenuItem *logMenuItems[] = {
 */
 bool UImanager::handleUIEvent(K197UIeventsource eventSource,
                               K197UIeventType eventType) {
-  if (k197dev.isCal()) return false;
-  if ( eventSource == K197key_REL && eventType==UIeventLongPress) { // This event is handled the same in all screen modes
-      if (isFullScreen())
-           showOptionsMenu();
-      else
-           showFullScreen();
-      return true;
+  if (k197dev.isCal())
+    return false;
+  if (eventSource == K197key_REL &&
+      eventType == UIeventLongPress) { // This event is handled the same in all
+                                       // screen modes
+    if (isFullScreen())
+      showOptionsMenu();
+    else
+      showFullScreen();
+    return true;
   }
   if (isMenuVisible()) {
     if (UImenu::getCurrentMenu()->handleUIEvent(eventSource, eventType))
@@ -573,44 +605,47 @@ bool UImanager::handleUIEvent(K197UIeventsource eventSource,
       showFullScreen();
       return true;
     }
-  } else switch (eventSource) { // Full scren mode
+  } else
+    switch (eventSource) { // Full scren mode
     case K197key_STO:
-        if (reassignStoRcl.getValue()) {
-            if ( eventType==UIeventLongPress ) {
-                K197screenMode screen_mode = uiman.getScreenMode();
-                if (screen_mode==K197sc_normal) uiman.setScreenMode(K197sc_minmax);  
-                else uiman.setScreenMode(K197sc_normal);
-            }
-            return true;
+      if (reassignStoRcl.getValue()) {
+        if (eventType == UIeventLongPress) {
+          K197screenMode screen_mode = uiman.getScreenMode();
+          if (screen_mode == K197sc_normal)
+            uiman.setScreenMode(K197sc_minmax);
+          else
+            uiman.setScreenMode(K197sc_normal);
         }
-        break;
+        return true;
+      }
+      break;
     case K197key_RCL:
-        if (reassignStoRcl.getValue()) {
-            return true;
-        }
-        break;
+      if (reassignStoRcl.getValue()) {
+        return true;
+      }
+      break;
     case K197key_REL:
-        if (eventType == UIeventDoubleClick) {
-            k197dev.resetStatistics();
-            //DebugOut.print('x');
-            return true;
-        }
-        break;
+      if (eventType == UIeventDoubleClick) {
+        k197dev.resetStatistics();
+        // DebugOut.print('x');
+        return true;
+      }
+      break;
     case K197key_DB:
-        if (additionalModes.getValue()) {
-            if (eventType == UIeventPress) {
-                if ( k197dev.isV() && k197dev.ismV() && k197dev.isDC()) {
-                    if (!k197dev.getTKMode()) { // TK mode is not yet enabled
-                        k197dev.setTKMode(true);  // Activate TK mode
-                        return true; // Skip normal handling in the main sketch
-                    }                
-                } else {
-                    k197dev.setTKMode(false);
-                }
+      if (additionalModes.getValue()) {
+        if (eventType == UIeventPress) {
+          if (k197dev.isV() && k197dev.ismV() && k197dev.isDC()) {
+            if (!k197dev.getTKMode()) { // TK mode is not yet enabled
+              k197dev.setTKMode(true);  // Activate TK mode
+              return true; // Skip normal handling in the main sketch
             }
+          } else {
+            k197dev.setTKMode(false);
+          }
         }
-        break;
-  }
+      }
+      break;
+    }
   return false;
   dxUtil.checkFreeStack();
 }
@@ -717,9 +752,9 @@ const char *UImanager::formatNumber(char buf[K197_MSG_SIZE], float f) {
 */
 void UImanager::logData() {
   if (k197dev.isCal()) // No logging while in Cal mode
-      return;
+    return;
   if ((!logEnable.getValue()) || (!BTman.validconnection()))
-      return;
+    return;
   if (logskip_counter < logSkip.getValue()) {
     logskip_counter++;
     return;

--- a/UImanager.cpp
+++ b/UImanager.cpp
@@ -167,8 +167,8 @@ void UImanager::setup() {
    to setup();
 */
 void UImanager::updateDisplay() {
-  if (isSplitScreen()) updateSplitScreen();
-  else if (getScreenMode() == K197sc_normal) updateNormalScreen();
+  if ( k197dev.isNotCal() && isSplitScreen()) updateSplitScreen();
+  else if ( k197dev.isCal() || (getScreenMode() == K197sc_normal) ) updateNormalScreen();
   else updateMinMaxScreen();
   dxUtil.checkFreeStack();
 }
@@ -470,8 +470,9 @@ void UImanager::clearScreen() {
       @param connected true if a BT connection is detected, false otherwise
 */
 void UImanager::updateBtStatus() {
-  if (isSplitScreen() || (getScreenMode() != K197sc_normal) )
-    return;
+  if (isSplitScreen() || (getScreenMode() != K197sc_normal) ) { //Note: No BT status in cal mode
+      return;
+  }
   unsigned int x = 95;
   unsigned int y = 2;
   u8g2.setCursor(x, y);
@@ -556,6 +557,7 @@ UImenuItem *logMenuItems[] = {
 */
 bool UImanager::handleUIEvent(K197UIeventsource eventSource,
                               K197UIeventType eventType) {
+  if (k197dev.isCal()) return false;
   if ( eventSource == K197key_REL && eventType==UIeventLongPress) { // This event is handled the same in all screen modes
       if (isFullScreen())
            showOptionsMenu();
@@ -714,8 +716,10 @@ const char *UImanager::formatNumber(char buf[K197_MSG_SIZE], float f) {
    datalogging is disabled or in no connection has been detected
 */
 void UImanager::logData() {
+  if (k197dev.isCal()) // No logging while in Cal mode
+      return;
   if ((!logEnable.getValue()) || (!BTman.validconnection()))
-    return;
+      return;
   if (logskip_counter < logSkip.getValue()) {
     logskip_counter++;
     return;

--- a/UImanager.cpp
+++ b/UImanager.cpp
@@ -63,8 +63,8 @@ UImenu UImainMenu(130, true); ///< the main menu for this application
 UImenu UIlogMenu(130);        ///< the submenu to set logging options
 
 #include "BTmanager.h"
-#include "UImanager.h"
 #include "K197PushButtons.h"
+#include "UImanager.h"
 #include "debugUtil.h"
 #include "dxUtil.h"
 #include "pinout.h"

--- a/UImanager.cpp
+++ b/UImanager.cpp
@@ -64,6 +64,7 @@ UImenu UIlogMenu(130);        ///< the submenu to set logging options
 
 #include "BTmanager.h"
 #include "UImanager.h"
+#include "K197PushButtons.h"
 #include "debugUtil.h"
 #include "dxUtil.h"
 #include "pinout.h"
@@ -626,6 +627,7 @@ bool UImanager::handleUIEvent(K197UIeventsource eventSource,
       break;
     case K197key_REL:
       if (eventType == UIeventDoubleClick) {
+        pushbuttons.cancelClickREL();
         k197dev.resetStatistics();
         // DebugOut.print('x');
         return true;

--- a/UImanager.h
+++ b/UImanager.h
@@ -91,7 +91,7 @@ public:
      @brief  check if display is in full screen mode
      @return true if in full screen mode
   */
- bool isFullScreen() {return screen_mode & K197sc_FullScreenBitMask;}
+ bool isFullScreen() {return k197dev.isCal() || ( (screen_mode & K197sc_FullScreenBitMask) != 0x00);}
   /*!
      @brief  check if display is in split screen mode
      @return true if in split screen mode
@@ -101,7 +101,7 @@ public:
      @brief  chek if the options menu is visible
      @return true if the menu is visible
   */
-  bool isMenuVisible() {return screen_mode & K197sc_MenuBitMask;};
+  bool isMenuVisible() {return k197dev.isNotCal() && ( (screen_mode & K197sc_MenuBitMask) != 0x00);};
   /*!
      @brief  set full screen mode
      @details also clears the other attributes as we do not keep track of them

--- a/UImanager.h
+++ b/UImanager.h
@@ -71,7 +71,7 @@ private:
 
   void setupMenus();
 
-  byte logskip_counter = 0; ///< counter used whenj data logging, counts how
+  byte logskip_counter = 0; ///< counter used when data logging, counts how
                             ///< many measurements are skipped
   void clearScreen();
   void setScreenMode(K197screenMode mode);
@@ -118,6 +118,7 @@ public:
      @return true if the menu is visible
   */
   void showOptionsMenu() { 
+    if (k197dev.isCal()) return;
     screen_mode = (K197screenMode) (screen_mode & K197sc_ScreenModeMask);
     screen_mode = (K197screenMode) (screen_mode | K197sc_MenuBitMask);
     clearScreen();
@@ -128,6 +129,7 @@ public:
      @return true if the menu is visible
   */
   void showDebugLog() {
+    if (k197dev.isCal()) return;
     // The debug log is shown in split mode if the menu is not active
     screen_mode = (K197screenMode) (screen_mode & K197sc_ScreenModeMask);
     clearScreen();

--- a/UImanager.h
+++ b/UImanager.h
@@ -31,15 +31,17 @@ extern U8G2LOG u8g2log; ///< This is used to display the debug log on the OLED
 /**************************************************************************/
 /*!
     @brief  Simple enum to identify the screen mode being displayed
-    @details the lower 4 bits control the screen mode, the higher 4 bit controls other attributes:
-    - bit 5 is used to distinguish between full screen and split screen 
+    @details the lower 4 bits control the screen mode, the higher 4 bit controls
+   other attributes:
+    - bit 5 is used to distinguish between full screen and split screen
     - bit 6 activates the menu
-    Note that not all combinations may be implemented, but in this way we can keep track of the mode when switching between full screen and split screen
+    Note that not all combinations may be implemented, but in this way we can
+   keep track of the mode when switching between full screen and split screen
 */
 /**************************************************************************/
 enum K197screenMode {
-  K197sc_normal = 0x01,   ///< equivalent to original K197
-  K197sc_minmax = 0x02,   ///< add statistics but less annunciators 
+  K197sc_normal = 0x01,            ///< equivalent to original K197
+  K197sc_minmax = 0x02,            ///< add statistics but less annunciators
   K197sc_FullScreenBitMask = 0x10, ///< full screen when set
   K197sc_MenuBitMask = 0x20,       ///< show menu when set
   K197sc_ScreenModeMask = 0x0f,    ///< Mask for mode bits
@@ -62,8 +64,10 @@ class UImanager {
 private:
   bool show_volt = false; ///< Show voltages if true (not currently used)
   bool show_temp = false; ///< Show temperature if true  (not currently used)
-  K197screenMode screen_mode = (K197screenMode) (K197sc_normal
-      | K197sc_FullScreenBitMask); ///< Keep track of how to display stuff...
+  K197screenMode screen_mode =
+      (K197screenMode)(K197sc_normal |
+                       K197sc_FullScreenBitMask); ///< Keep track of how to
+                                                  ///< display stuff...
 
   void updateNormalScreen();
   void updateMinMaxScreen();
@@ -80,8 +84,9 @@ private:
      @return screen mode, it must be one of the displayXXX constants defined in
      class UImanager
   */
-  K197screenMode getScreenMode() { return (K197screenMode) (screen_mode & K197sc_ScreenModeMask); };
-
+  K197screenMode getScreenMode() {
+    return (K197screenMode)(screen_mode & K197sc_ScreenModeMask);
+  };
 
 public:
   UImanager(){}; ///< default constructor for the class
@@ -91,49 +96,53 @@ public:
      @brief  check if display is in full screen mode
      @return true if in full screen mode
   */
- bool isFullScreen() {return k197dev.isCal() || ( (screen_mode & K197sc_FullScreenBitMask) != 0x00);}
+  bool isFullScreen() {
+    return k197dev.isCal() ||
+           ((screen_mode & K197sc_FullScreenBitMask) != 0x00);
+  }
   /*!
      @brief  check if display is in split screen mode
      @return true if in split screen mode
   */
-  bool isSplitScreen() {return !isFullScreen();}
+  bool isSplitScreen() { return !isFullScreen(); }
   /*!
      @brief  chek if the options menu is visible
      @return true if the menu is visible
   */
-  bool isMenuVisible() {return k197dev.isNotCal() && ( (screen_mode & K197sc_MenuBitMask) != 0x00);};
+  bool isMenuVisible() {
+    return k197dev.isNotCal() && ((screen_mode & K197sc_MenuBitMask) != 0x00);
+  };
   /*!
      @brief  set full screen mode
-     @details also clears the other attributes as we do not keep track of them
-     @return true if the menu is visible
+     @details also clears the other attributes
   */
-  void showFullScreen() { 
-    screen_mode = (K197screenMode) (screen_mode & K197sc_ScreenModeMask); 
-    screen_mode = (K197screenMode) (screen_mode | K197sc_FullScreenBitMask); 
+  void showFullScreen() {
+    screen_mode = (K197screenMode)(screen_mode & K197sc_ScreenModeMask);
+    screen_mode = (K197screenMode)(screen_mode | K197sc_FullScreenBitMask);
     clearScreen();
   };
   /*!
      @brief  show the option menu
-     @details also clears the other attributes as we do not keep track of them
-     @return true if the menu is visible
+     @details also clears the other attributes
   */
-  void showOptionsMenu() { 
-    if (k197dev.isCal()) return;
-    screen_mode = (K197screenMode) (screen_mode & K197sc_ScreenModeMask);
-    screen_mode = (K197screenMode) (screen_mode | K197sc_MenuBitMask);
+  void showOptionsMenu() {
+    if (k197dev.isCal())
+      return;
+    screen_mode = (K197screenMode)(screen_mode & K197sc_ScreenModeMask);
+    screen_mode = (K197screenMode)(screen_mode | K197sc_MenuBitMask);
     clearScreen();
   };
   /*!
      @brief  show the option menu
-     @details also clears the other attributes as we do not keep track of them
-     @return true if the menu is visible
+     @details also clears the other attributes
   */
   void showDebugLog() {
-    if (k197dev.isCal()) return;
+    if (k197dev.isCal())
+      return;
     // The debug log is shown in split mode if the menu is not active
-    screen_mode = (K197screenMode) (screen_mode & K197sc_ScreenModeMask);
+    screen_mode = (K197screenMode)(screen_mode & K197sc_ScreenModeMask);
     clearScreen();
-  }; 
+  };
 
   void updateDisplay();
   void updateBtStatus();
@@ -148,7 +157,6 @@ public:
   void logData();
 
   static const char *formatNumber(char buf[K197_MSG_SIZE], float f);
-
 };
 
 extern UImanager uiman;

--- a/UImenu.cpp
+++ b/UImenu.cpp
@@ -223,7 +223,7 @@ bool UImenu::handleUIEvent(K197UIeventsource eventSource,
   }
   // In the following we use click events to be able to assign the LongPress to
   // other events
-  if ( eventSource == K197key_REL && eventType == UIeventClick ) { // up
+  if (eventSource == K197key_REL && eventType == UIeventClick) { // up
     if (selectedItem == 0)
       return false;
     for (byte i = selectedItem; i > 0; i--) {

--- a/dxUtil.cpp
+++ b/dxUtil.cpp
@@ -242,6 +242,6 @@ void dxUtilClass::reportStack(bool reportAlways) {
   }
   if (reportAlways) {
     DebugOut.print(F("Stack="));
-    DebugOut.println(minStack);
+    DebugOut.print(minStack);
   }
 }

--- a/notes.txt
+++ b/notes.txt
@@ -1,8 +1,0 @@
- push( (UI_STO_VPORT.IN & (UI_STO_bm | UI_RCL_bm)) | (UI_REL_VPORT.IN & (UI_REL_bm | UI_DB_bm)) ); 
-CCL_interrupt_handler():
-    7eba:	8e b1       	in	r24, 0x0e	; 14
-    7ebc:	96 b3       	in	r25, 0x16	; 22
-    7ebe:	80 7a       	andi	r24, 0xA0	; 160
-    7ec0:	93 70       	andi	r25, 0x03	; 3
-    7ec2:	89 2b       	or	r24, r25
-push():

--- a/notes.txt
+++ b/notes.txt
@@ -1,0 +1,8 @@
+ push( (UI_STO_VPORT.IN & (UI_STO_bm | UI_RCL_bm)) | (UI_REL_VPORT.IN & (UI_REL_bm | UI_DB_bm)) ); 
+CCL_interrupt_handler():
+    7eba:	8e b1       	in	r24, 0x0e	; 14
+    7ebc:	96 b3       	in	r25, 0x16	; 22
+    7ebe:	80 7a       	andi	r24, 0xA0	; 160
+    7ec0:	93 70       	andi	r25, 0x03	; 3
+    7ec2:	89 2b       	or	r24, r25
+push():

--- a/pinout.h
+++ b/pinout.h
@@ -115,7 +115,10 @@
 #define UI_REL_Event Event4
 #define UI_DB_Event  Event5
 
-// Othert TIMER definitions
+// Other TIMER definitions and checks
+#ifdef MILLIS_USE_TIMERA0
+  #error "This sketch takes over TCA0 - please use a different timer for millis"
+#endif
 #define TCA_OVF_vect TCA0_OVF_vect
 #define TCA_CMP0_vect TCA0_CMP0_vect
 inline void takeOverTCA() {takeOverTCA0();}

--- a/pinout.h
+++ b/pinout.h
@@ -11,19 +11,19 @@
   This file is part of the Arduino K197Display sketch, please see
   https://github.com/alx2009/K197Display for more information
 
-  In this file we consolidate all I/O pin definitions for this application. In
-  addition, we include generally useful constants
+  In this file we consolidate all I/O pin definitions and other HW dependent
+  compile options.
 
   Pin definitions are in the form PIN_Pxn where x is PORT x and n is pin n in
   said port. This is the preferred form for dxCore (rather than the pin number
   commonly used with the AVR cores)
 
-  In addition to pin numbers, we also define VPORT and bitmaps for direct port
-  manipulation and a number of useful constants
+  In addition to pin numbers, we also define PORT, VPORT and bitmaps for direct
+  port manipulation and a number of useful constants
 
   Note for users coming from the legacy AVR! PIN_PC1 would normally be the MISO
   pin for the SPI1 port, configured as an output. We use SPI1 to talk to the
-  K197 as client. Now, we have no data to send to the 197, so we re-use PIN_PC1
+  K197 as client. We have no data to send to the 197, so we re-use PIN_PC1
   as an input instead. This would not be possible for the old AVRs, but it is
   supported by the AVR DB when the SPI peripheral is in client mode
 */
@@ -84,7 +84,7 @@
 #define UI_DB_VPORT VPORTF    ///< VPORT for UI_DB pin
 
 // Timer port definitions
-#   define AVR_TCA_PORT   TCA0
+#define AVR_TCA_PORT TCA0 ///< define the TCA timer instance to use
 
 // UART definitions
 #define BT_USART USART0 ///< This is the UART connected to the bluetooth module
@@ -109,19 +109,22 @@
 // PIN SWAP Options
 #define OLED_SPI_SWAP_OPTION SPI0_SWAP_DEFAULT ///< SPI swap to use for OLED
 
-//Event channels
-#define UI_STO_Event Event2
-#define UI_RCL_Event Event3
-#define UI_REL_Event Event4
-#define UI_DB_Event  Event5
+// Event channels
+#define UI_STO_Event Event2 ///< Event channel for STO pushbutton
+#define UI_RCL_Event Event3 ///< Event channel for RCL pushbutton
+#define UI_REL_Event Event4 ///< Event channel for REL pushbutton
+#define UI_DB_Event Event5  ///< Event channel for DB pushbutton
 
 // Other TIMER definitions and checks
 #ifdef MILLIS_USE_TIMERA0
-  #error "This sketch takes over TCA0 - please use a different timer for millis"
+#error "This sketch takes over TCA0 - please use a different timer for millis"
 #endif
-#define TCA_OVF_vect TCA0_OVF_vect
-#define TCA_CMP0_vect TCA0_CMP0_vect
-inline void takeOverTCA() {takeOverTCA0();}
+#define TCA_OVF_vect TCA0_OVF_vect   ///< TCA OVF int. instance to use
+#define TCA_CMP0_vect TCA0_CMP0_vect ///< TCA CMP0 int. instance to use
+
+inline void takeOverTCA() {
+  takeOverTCA0();
+} ///< define the instance of TCA to take over
 
 extern const char
     CH_SPACE; ///< External constant used whenever we need a ' ' character.

--- a/pinout.h
+++ b/pinout.h
@@ -83,6 +83,9 @@
 #define UI_REL_VPORT VPORTF   ///< VPORT for UI_REL pin
 #define UI_DB_VPORT VPORTF    ///< VPORT for UI_DB pin
 
+// Timer port definitions
+#   define AVR_TCA_PORT   TCA0
+
 // UART definitions
 #define BT_USART USART0 ///< This is the UART connected to the bluetooth module
 
@@ -112,7 +115,11 @@
 #define UI_REL_Event Event4
 #define UI_DB_Event  Event5
 
-// Generally useful constants
+// Othert TIMER definitions
+#define TCA_OVF_vect TCA0_OVF_vect
+#define TCA_CMP0_vect TCA0_CMP0_vect
+inline void takeOverTCA() {takeOverTCA0();}
+
 extern const char
     CH_SPACE; ///< External constant used whenever we need a ' ' character.
               ///< Having it as global constant saves a few bytes of RAM

--- a/pinout.h
+++ b/pinout.h
@@ -106,6 +106,12 @@
 // PIN SWAP Options
 #define OLED_SPI_SWAP_OPTION SPI0_SWAP_DEFAULT ///< SPI swap to use for OLED
 
+//Event channels
+#define UI_STO_Event Event2
+#define UI_RCL_Event Event3
+#define UI_REL_Event Event4
+#define UI_DB_Event  Event5
+
 // Generally useful constants
 extern const char
     CH_SPACE; ///< External constant used whenever we need a ' ' character.


### PR DESCRIPTION
Now push buttons are handled via interrupts. In this way there are no more lost clicks and double clicks.

The normal action of the REL button is delayed about 600 ms so that a double click will delete statistics without changign to/from relative mode. 